### PR TITLE
[add] .pre-commit-configを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 !*.py
 !*.txt
 !*.html
+
+!.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]


### PR DESCRIPTION
## .pre-commit-configを追加しました

参考 https://zenn.dev/yiskw713/articles/3c3b4022f3e3f22d276d

### Usage

for Mac
```
brew install pre-commit
pre-commit install
```

これで .git/hooks/pre-commit が作られるかと思います。
pre-commitとはコミット前に自動で行ってくれる操作を書いているファイルで、この設定ではコミット前にコミットに含まれるファイルにpython formatterのblackとisortをかけるように設定してあります。
(コミットが多少重くなります)

pre-commitの操作がかかってないファイルをコミットしようとすると警告を出して修正してくれるので、その修正を再ステージング -> コミットして使って下さい

他には
```
pre-commit run --files $(git diff --name-only --cached)
```
で手動でコミット前にかけることもできます(ステージングされたファイルに対して)

