### PR TITLE
[add] .vscodeにdjango-htmlをhtml認識させるように設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 !*.py
 !*.txt
 !*.html
+
+!.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "emmet.includeLanguages": {
+    "django-html": "html"
+  },
+}


### PR DESCRIPTION
## .vscodeにdjango-htmlをhtml認識させるように設定しました

具体的なことはvcで説明しますが、djangoの中に入っているhtmlに対してhtmlの自動補完等が使えなかったため追加しました