### PR TITLE
[add] login pageのbackendを実装しました

### DIFF
--- a/web/accounts/templates/accounts/login.html
+++ b/web/accounts/templates/accounts/login.html
@@ -1,5 +1,13 @@
 {% extends 'base.html' %}
 
+{% block title %}
+  Login
+{% endblock %}
+
+{% block header %}
+  Login Page
+{% endblock %}
+
 {% block content %}
   <main class="form-signin d-flex flex-column justify-content-center align-items-center vh-100">
     {% if form.errors %}

--- a/web/accounts/templates/base.html
+++ b/web/accounts/templates/base.html
@@ -1,23 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Required meta tags -->
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-    <link href="https://getbootstrap.com/docs/5.3/assets/css/docs.css" rel="stylesheet" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous" />
     <title>
       {% block title %}
-        Base site
+
       {% endblock %}
     </title>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   </head>
-
   <body>
-    <div id="content">
+    <br />
+    <div class="container">
+      <h1>
+        {% block header %}
+
+        {% endblock %}
+      </h1>
       {% block content %}
 
       {% endblock %}
     </div>
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/web/accounts/tests.py
+++ b/web/accounts/tests.py
@@ -1,3 +1,42 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+
+def create_user(username, password):
+    return User.objects.create_user(username=username, password=password)
+
+
+class CustomLoginViewTests(TestCase):
+    def test_custom_login_view_template(self):
+        """ログインページが正しいテンプレートを使っていることを確認する"""
+        response = self.client.get(reverse("accounts:login"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "accounts/login.html")
+
+    def test_custom_login_view_valid_login(self):
+        """ユーザーを作成し正しいユーザー名とパスワードでログインできることを確認する"""
+        user_name = "testuser"
+        user_password = "password123"
+        create_user(username=user_name, password=user_password)
+        response = self.client.post(
+            reverse("accounts:login"),
+            {"username": user_name, "password": user_password},
+            follow=True,
+        )
+        # リダイレクト先をまだ設定していないため
+        # self.assertEqual(response.status_code, 200)
+        # self.assertRedirects(response, reverse("home"))
+
+    def test_custom_login_view_invalid_login(self):
+        """ユーザーを作成し間違ったパスワードでログインできないことを確認する"""
+        user_name = "testuser"
+        user_password = "password123"
+        create_user(username=user_name, password=user_password)
+        response = self.client.post(
+            reverse("accounts:login"),
+            {"username": user_name, "password": "wrongpassword"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "accounts/login.html")
+        self.assertFalse(response.context["user"].is_authenticated)


### PR DESCRIPTION
## login pageのbackendを追加しました

バックエンド実装といってもDjangoデフォルトのLoginViewを使ったためほぼ変更はありません。
- base.htmlを使いやすいように変更
- CustomLoginViewに対するテストを追加

login page自体は今までの実装でも動かせていて、コンテナ内で以下のコマンドでattach shellして手動でユーザーを作ったら試せます(これを自動化したのがテスト)
```
python3 manage.py shell
>>> from django.contrib.auth.models import User
>>> user = User.objects.create_user("user", "user@gmail", "userpass")
>>> user.save()
```