### PR TITLE
[add] TournamentページのUI作成

### DIFF
--- a/web/core/settings.py
+++ b/web/core/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "accounts",
     "tournament",
+    "matches",
 ]
 
 MIDDLEWARE = [

--- a/web/core/urls.py
+++ b/web/core/urls.py
@@ -19,7 +19,7 @@ from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
-    path("tournament/matches/", include("matches.urls")),
+    path("tournament/matches/", include("tournament.urls")),
     path("tournament/", include("tournament.urls")),
     path("accounts/", include("accounts.urls")),
     path("admin/", admin.site.urls),

--- a/web/core/urls.py
+++ b/web/core/urls.py
@@ -20,7 +20,6 @@ from django.urls import include, path
 from homepage.views import homepage
 
 urlpatterns = [
-    path("tournament/matches/", include("tournament.urls")),
     path("tournament/", include("tournament.urls")),
     path("accounts/", include("accounts.urls")),
     path("admin/", admin.site.urls),

--- a/web/core/urls.py
+++ b/web/core/urls.py
@@ -19,6 +19,7 @@ from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
+    path("tournament/matches/", include("matches.urls")),
     path("tournament/", include("tournament.urls")),
     path("accounts/", include("accounts.urls")),
     path("admin/", admin.site.urls),

--- a/web/matches/admin.py
+++ b/web/matches/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/web/matches/apps.py
+++ b/web/matches/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class MatchesConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "matches"

--- a/web/matches/models.py
+++ b/web/matches/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/web/matches/static/matches/css/style.css
+++ b/web/matches/static/matches/css/style.css
@@ -1,0 +1,48 @@
+body {
+    font-family: 'Istok Web', sans-serif;background: url("http://picjumbo.com/wp-content/uploads/HNCK2189-1300x866.jpg") no-repeat #000;background-size: cover;min-height: 100%;margin: 0;}
+    .hero {position:relative; text-align: center; overflow: hidden; color: #fcfcfc; }
+    .hero h1 {font-family: 'Holtwood One SC', serif;font-weight: normal;font-size: 5.4em;margin:0 0 20px; text-shadow:0 0 12px rgba(0, 0, 0, 0.5);text-transform: uppercase;letter-spacing:-1px;}
+    .hero p {font-family: 'Abel', sans-serif;text-transform: uppercase; color: #5CCA87; letter-spacing: 6px;text-shadow:0 0 12px rgba(0, 0, 0, 0.5);font-size: 1.2em;}
+    .hero-wrap {padding: 3.5em 10px;}
+    .hero p.intro {font-family: 'Holtwood One SC', serif;text-transform: uppercase;letter-spacing: 1px;font-size: 3em;margin-bottom:-40px;
+}
+
+.matchup {
+    background-color: #ffffff;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    padding: 10px 20px;
+}
+
+.team {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 0;
+    font-weight: 500;
+}
+
+.team-top {
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 5px;
+}
+
+.score {
+    font-weight: bold;
+    color: #2c3e50;
+}
+
+.winner .score {
+    color: #28a745;
+}
+
+.text-uppercase {
+    text-transform: uppercase;
+}
+
+.text-success {
+    color: #3F915F;
+}
+
+.text-secondary {
+    color: #3a3a3a;
+}

--- a/web/matches/templates/matches/matches.html
+++ b/web/matches/templates/matches/matches.html
@@ -9,8 +9,8 @@
     <link href="{% static 'matches/css/style.css' %}" rel="stylesheet">
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
-
 </head>
+<body>
 <header class="hero">
     <div class="hero-wrap">
         <h1 id="headline">Tournament</h1>
@@ -18,8 +18,6 @@
     </div>
 </header>
 
-</head>
-<body>
 <div class="container my-5 ">
     <div class="row text-center">
         <div class="col">
@@ -37,20 +35,79 @@
         <!-- Round 1 -->
         <div class="col-md-4">
             <div class="matchup mb-4">
-                <div class="team team-top">{{ players.player1 }}<span class="score">76</span></div>
-                <div class="team team-bottom">{{ players.player2 }}<span class="score">82</span></div>
+                <div class="team team-top">
+                    {% if players.player1 %}
+                    {{ players.player1 }}
+                    {% else %}
+                    None
+                    {% endif %}
+                    <span class="score">76</span>
+                </div>
+                <div class="team team-bottom">
+                    {% if players.player2 %}
+                    {{ players.player2 }}
+                    {% else %}
+                    None
+                    {% endif %}
+                    <span class="score">82</span>
+                </div>
             </div>
+
             <div class="matchup mb-4">
-                <div class="team team-top">{{ players.player3 }}<span class="score">76</span></div>
-                <div class="team team-bottom">{{ players.player4 }}<span class="score">82</span></div>
+                <div class="team team-top">
+                    {% if players.player3 %}
+                    {{ players.player3 }}
+                    {% else %}
+                    None
+                    {% endif %}
+                    <span class="score">76</span>
+                </div>
+                <div class="team team-bottom">
+                    {% if players.player4 %}
+                    {{ players.player4 }}
+                    {% else %}
+                    None
+                    {% endif %}
+                    <span class="score">82</span>
+                </div>
             </div>
+
             <div class="matchup mb-4">
-                <div class="team team-top">{{ players.player5 }}<span class="score">76</span></div>
-                <div class="team team-bottom">{{ players.player6 }}<span class="score">82</span></div>
+                <div class="team team-top">
+                    {% if players.player5 %}
+                    {{ players.player5 }}
+                    {% else %}
+                    None
+                    {% endif %}
+                    <span class="score">76</span>
+                </div> <!-- Close team team-top -->
+                <div class="team team-bottom">
+                    {% if players.player6 %}
+                    {{ players.player6 }}
+                    {% else %}
+                    None
+                    {% endif %}
+                    <span class="score">82</span>
+                </div>
             </div>
+
             <div class="matchup mb-4">
-                <div class="team team-top">{{ players.player7 }}<span class="score">76</span></div>
-                <div class="team team-bottom">{{ players.player8 }}<span class="score">82</span></div>
+                <div class="team team-top">
+                    {% if players.player7 %}
+                    {{ players.player7 }}
+                    {% else %}
+                    None
+                    {% endif %}
+                    <span class="score">76</span>
+                </div>
+                <div class="team team-bottom">
+                    {% if players.player8 %}
+                    {{ players.player8 }}
+                    {% else %}
+                    None
+                    {% endif %}
+                    <span class="score">82</span>
+                </div>
             </div>
         </div>
 

--- a/web/matches/templates/matches/matches.html
+++ b/web/matches/templates/matches/matches.html
@@ -37,20 +37,20 @@
         <!-- Round 1 -->
         <div class="col-md-4">
             <div class="matchup mb-4">
-                <div class="team team-top">player1<span class="score">76</span></div>
-                <div class="team team-bottom winner">player2<span class="score">82</span></div>
+                <div class="team team-top">{{ players.player1 }}<span class="score">76</span></div>
+                <div class="team team-bottom">{{ players.player2 }}<span class="score">82</span></div>
             </div>
             <div class="matchup mb-4">
-                <div class="team team-top">player3<span class="score">64</span></div>
-                <div class="team team-bottom">player4<span class="score">56</span></div>
+                <div class="team team-top">{{ players.player3 }}<span class="score">76</span></div>
+                <div class="team team-bottom">{{ players.player4 }}<span class="score">82</span></div>
             </div>
             <div class="matchup mb-4">
-                <div class="team team-top">player5<span class="score">68</span></div>
-                <div class="team team-bottom">player6<span class="score">54</span></div>
+                <div class="team team-top">{{ players.player5 }}<span class="score">76</span></div>
+                <div class="team team-bottom">{{ players.player6 }}<span class="score">82</span></div>
             </div>
             <div class="matchup mb-4">
-                <div class="team team-top">player7<span class="score">74</span></div>
-                <div class="team team-bottom winner">player8<span class="score">92</span></div>
+                <div class="team team-top">{{ players.player7 }}<span class="score">76</span></div>
+                <div class="team team-bottom">{{ players.player8 }}<span class="score">82</span></div>
             </div>
         </div>
 

--- a/web/matches/templates/matches/matches.html
+++ b/web/matches/templates/matches/matches.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>トーナメント</title>
+    {% load static %}
+    <link href="{% static 'matches/css/style.css' %}" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+
+</head>
+<header class="hero">
+    <div class="hero-wrap">
+        <h1 id="headline">Tournament</h1>
+        <p class="year"><i class="fa fa-star"></i> 2024 <i class="fa fa-star"></i></p>
+    </div>
+</header>
+
+</head>
+<body>
+<div class="container my-5">
+    <div class="row text-center">
+        <div class="col">
+            <h3 class="text-uppercase text-secondary">Round 1</h3>
+        </div>
+        <div class="col">
+            <h3 class="text-uppercase text-secondary">Round 2</h3>
+        </div>
+        <div class="col">
+            <h3 class="text-uppercase text-secondary">Round 3</h3>
+        </div>
+    </div>
+
+    <div class="row">
+        <!-- Round 1 -->
+        <div class="col-md-4">
+            <div class="matchup mb-4">
+                <div class="team team-top">player1<span class="score">76</span></div>
+                <div class="team team-bottom winner">player2<span class="score">82</span></div>
+            </div>
+            <div class="matchup mb-4">
+                <div class="team team-top">player3<span class="score">64</span></div>
+                <div class="team team-bottom">player4<span class="score">56</span></div>
+            </div>
+            <div class="matchup mb-4">
+                <div class="team team-top">player5<span class="score">68</span></div>
+                <div class="team team-bottom">player6<span class="score">54</span></div>
+            </div>
+            <div class="matchup mb-4">
+                <div class="team team-top">player7<span class="score">74</span></div>
+                <div class="team team-bottom winner">player8<span class="score">92</span></div>
+            </div>
+        </div>
+
+        <!-- Round 2 -->
+        <div class="col-md-4 d-flex flex-column justify-content-center">
+            <div class="matchup mb-5">
+                <div class="team team-top">&nbsp;<span class="score">&nbsp;</span></div>
+                <div class="team team-bottom">&nbsp;<span class="score">&nbsp;</span></div>
+            </div>
+            <div class="matchup mb-5">
+                <div class="team team-top">&nbsp;<span class="score">&nbsp;</span></div>
+                <div class="team team-bottom">&nbsp;<span class="score">&nbsp;</span></div>
+            </div>
+        </div>
+
+        <!-- Round 3 -->
+        <div class="col-md-4 d-flex flex-column justify-content-center">
+            <div class="matchup">
+                <div class="team team-top">&nbsp;<span class="score">&nbsp;</span></div>
+                <div class="team team-bottom">&nbsp;<span class="score">&nbsp;</span></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/web/matches/templates/matches/matches.html
+++ b/web/matches/templates/matches/matches.html
@@ -20,7 +20,7 @@
 
 </head>
 <body>
-<div class="container my-5">
+<div class="container my-5 ">
     <div class="row text-center">
         <div class="col">
             <h3 class="text-uppercase text-secondary">Round 1</h3>

--- a/web/matches/tests.py
+++ b/web/matches/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/web/matches/urls.py
+++ b/web/matches/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from . import views
+
+app_name = "matches"
+urlpatterns = [
+    path("", views.matches_view, name="matches"),
+]

--- a/web/matches/urls.py
+++ b/web/matches/urls.py
@@ -1,8 +1,0 @@
-from django.urls import path
-
-from . import views
-
-app_name = "matches"
-urlpatterns = [
-    path("", views.matches_view, name="matches"),
-]

--- a/web/matches/views.py
+++ b/web/matches/views.py
@@ -1,6 +1,19 @@
 from django.shortcuts import render
 
 
-# Create your views here.
 def matches_view(request):
-    return render(request, "matches/matches.html")
+    if request.method == "POST":
+        players = {
+            "player1": request.POST.get("player1"),
+            "player2": request.POST.get("player2"),
+            "player3": request.POST.get("player3"),
+            "player4": request.POST.get("player4"),
+            "player5": request.POST.get("player5"),
+            "player6": request.POST.get("player6"),
+            "player7": request.POST.get("player7"),
+            "player8": request.POST.get("player8"),
+        }
+        return render(request, "matches/matches.html", {"players": players})
+    else:
+        # GETリクエストの場合の処理（必要に応じて）
+        return render(request, "matches/matches.html")

--- a/web/matches/views.py
+++ b/web/matches/views.py
@@ -1,0 +1,6 @@
+from django.shortcuts import render
+
+
+# Create your views here.
+def matches_view(request):
+    return render(request, "matches/matches.html")

--- a/web/tournament/templates/tournament/tournament.html
+++ b/web/tournament/templates/tournament/tournament.html
@@ -77,7 +77,7 @@
 
 <!-- 決定ボタンをページ下部中央に追加 -->
 <div class="text-center mt-3 mb-4">
-    <button type="button" class="btn btn-outline-secondary"> 決定 </button>
+    <a href="{% url 'tournament:matches' %}" class="btn btn-outline-secondary">決定</a>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>

--- a/web/tournament/templates/tournament/tournament.html
+++ b/web/tournament/templates/tournament/tournament.html
@@ -34,52 +34,59 @@
             justify-content: center;
             max-width: 500px; /* 中央寄せする幅を制限 */
         }
+        .submit-button {
+            position: absolute;
+            bottom: 160px; /* 下部に配置 */
+            left: 50%;
+            transform: translateX(-50%)
+        }
     </style>
 </head>
 <body>
 <div class="container">
     <h1 class="text-center">メンバー</h1>
-    <div id="round1" class="round">
-        <div class="bracket mb-4">
-            <div class="match">
-                <input type="text" class="form-control text-center" placeholder="プレイヤー1">
+    <form method="post" action="{% url 'tournament:matches' %}">
+        {% csrf_token %}
+        <div id="round1" class="round">
+            <div class="bracket mb-4">
+                <div class="match">
+                    <input type="text" name="player1" placeholder="プレイヤー1">
+                </div>
+                <div class="match">
+                    <input type="text" name="player2" placeholder="プレイヤー2">
+                </div>
             </div>
-            <div class="match">
-                <input type="text" class="form-control text-center" placeholder="プレイヤー2">
+            <div class="bracket mb-4">
+                <div class="match">
+                    <input type="text" name="player3" placeholder="プレイヤー3">
+                </div>
+                <div class="match">
+                    <input type="text" name="player4" placeholder="プレイヤー4">
+                </div>
+            </div>
+            <div class="bracket mb-4">
+                <div class="match">
+                    <input type="text" name="player5" placeholder="プレイヤー5">
+                </div>
+                <div class="match">
+                    <input type="text" name="player6" placeholder="プレイヤー6">
+                </div>
+            </div>
+            <div class="bracket mb-4">
+                <div class="match">
+                    <input type="text" name="player7" placeholder="プレイヤー7">
+                </div>
+                <div class="match">
+                    <input type="text" name="player8" placeholder="プレイヤー8">
+                </div>
             </div>
         </div>
-        <div class="bracket mb-4">
-            <div class="match">
-                <input type="text" class="form-control text-center" placeholder="プレイヤー3">
-            </div>
-            <div class="match">
-                <input type="text" class="form-control text-center" placeholder="プレイヤー4">
-            </div>
+        <!-- 決定ボタンをページ下部中央に追加 -->
+        <div class="submit-button">
+            <button type="submit" class="btn btn-outline-secondary">決定</button>
         </div>
-        <div class="bracket mb-4">
-            <div class="match">
-                <input type="text" class="form-control text-center" placeholder="プレイヤー5">
-            </div>
-            <div class="match">
-                <input type="text" class="form-control text-center" placeholder="プレイヤー6">
-            </div>
-        </div>
-        <div class="bracket mb-4">
-            <div class="match">
-                <input type="text" class="form-control text-center" placeholder="プレイヤー7">
-            </div>
-            <div class="match">
-                <input type="text" class="form-control text-center" placeholder="プレイヤー8">
-            </div>
-        </div>
-    </div>
+    </form>
 </div>
-
-<!-- 決定ボタンをページ下部中央に追加 -->
-<div class="text-center mt-3 mb-4">
-    <a href="{% url 'tournament:matches' %}" class="btn btn-outline-secondary">決定</a>
-</div>
-
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/web/tournament/urls.py
+++ b/web/tournament/urls.py
@@ -1,8 +1,12 @@
 from django.urls import path
+from matches import views as matches_views  # matches/views.pyからインポート
 
-from . import views
+from . import views  # tournament/views.pyからインポート
 
 app_name = "tournament"
 urlpatterns = [
     path("", views.TournamentView.as_view(), name="tournament"),
+    path(
+        "matches/", matches_views.matches_view, name="matches"
+    ),  # matchesのビューを参照
 ]


### PR DESCRIPTION
**＜やったこと＞**
1. TournamentページのUI作成
2. /tournametページ内の「決定」ボタンを押した後に、/matchesページに飛べるようにしました

**＜確認方法＞**
1. http://localhost:8000/tournament/
2. 決定ボタンを押す
3. http://localhost:8000/tournament/matches ページに遷移

**＜共有事項＞**
1. 名前のデータ保存は未実装です。（razaさんと考えていく）
2. 名前が何も入力されていなくてもエラーなどは出ず、ページ遷移します。
3. https://github.com/sophia-programming/42-transcendence/pull/18をmerge後にmerge