### PR TITLE
[update] OTP認証に対するテスト追加

### DIFF
--- a/web/accounts/tests.py
+++ b/web/accounts/tests.py
@@ -60,10 +60,13 @@ class SetupOTPViewTests(TestCase):
         self.client.login(username="testuser", password="password123")  # loginが必要
 
     def test_setup_otp_view_get(self):
-        """OTPセットアップページが正しいテンプレートを使っていることを確認する"""
+        """OTPセットアップページが正しいテンプレートを使っていることを確認し、デバイスが作成されていて無効であることを確認する"""
         response = self.client.get(reverse("accounts:setup_otp"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "accounts/setup_otp.html")
+        device = TOTPDevice.objects.filter(user=self.user).first()
+        self.assertIsNotNone(device)
+        self.assertFalse(device.confirmed)
 
     def test_setup_otp_view_post(self):
         """OTPセットアップが正しく完了することを確認する"""
@@ -72,6 +75,9 @@ class SetupOTPViewTests(TestCase):
         response = self.client.post(reverse("accounts:setup_otp"))
         self.user.refresh_from_db()
         self.assertTrue(self.user.otp_enabled)
+        device = TOTPDevice.objects.filter(user=self.user).first()
+        self.assertIsNotNone(device)
+        self.assertTrue(device.confirmed)
         # self.assertRedirects(response, reverse("accounts:home")) # homeが未設定のため
 
 

--- a/web/accounts/tests.py
+++ b/web/accounts/tests.py
@@ -1,13 +1,21 @@
-from django.contrib.auth.models import User
+import time
+
 from django.test import TestCase
 from django.urls import reverse
+from django_otp.oath import TOTP
+from django_otp.plugins.otp_totp.models import TOTPDevice
 
-
-def create_user(username, password):
-    return User.objects.create_user(username=username, password=password)
+from .models import CustomUser
 
 
 class CustomLoginViewTests(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(
+            username="testuser", password="password123"
+        )
+        self.user.otp_enabled = True
+        self.user.save()
+
     def test_custom_login_view_template(self):
         """ログインページが正しいテンプレートを使っていることを確認する"""
         response = self.client.get(reverse("accounts:login"))
@@ -16,27 +24,84 @@ class CustomLoginViewTests(TestCase):
 
     def test_custom_login_view_valid_login(self):
         """ユーザーを作成し正しいユーザー名とパスワードでログインできることを確認する"""
-        user_name = "testuser"
-        user_password = "password123"
-        create_user(username=user_name, password=user_password)
         response = self.client.post(
             reverse("accounts:login"),
-            {"username": user_name, "password": user_password},
+            {"username": "testuser", "password": "password123"},
             follow=True,
         )
-        # リダイレクト先をまだ設定していないため
-        # self.assertEqual(response.status_code, 200)
-        # self.assertRedirects(response, reverse("home"))
+        self.assertRedirects(response, reverse("accounts:verify_otp"))
 
     def test_custom_login_view_invalid_login(self):
         """ユーザーを作成し間違ったパスワードでログインできないことを確認する"""
-        user_name = "testuser"
-        user_password = "password123"
-        create_user(username=user_name, password=user_password)
         response = self.client.post(
             reverse("accounts:login"),
-            {"username": user_name, "password": "wrongpassword"},
+            {"username": "testuser", "password": "wrongpassword"},
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "accounts/login.html")
         self.assertFalse(response.context["user"].is_authenticated)
+
+
+class SetupOTPViewTests(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(
+            username="testuser", password="password123"
+        )
+        self.client.login(username="testuser", password="password123")  # loginが必要
+
+    def test_setup_otp_view_get(self):
+        """OTPセットアップページが正しいテンプレートを使っていることを確認する"""
+        response = self.client.get(reverse("accounts:setup_otp"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "accounts/setup_otp.html")
+
+    def test_setup_otp_view_post(self):
+        """OTPセットアップが正しく完了することを確認する"""
+        # まずGETリクエストを送信してデバイスを設定
+        self.client.get(reverse("accounts:setup_otp"))
+        response = self.client.post(reverse("accounts:setup_otp"))
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.otp_enabled)
+        # self.assertRedirects(response, reverse("accounts:home")) # homeが未設定のため
+
+
+class VerifyOTPViewTests(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(
+            username="testuser", password="password123"
+        )
+        self.client.login(username="testuser", password="password123")  # loginが必要
+        self.device = TOTPDevice.objects.create(
+            user=self.user, confirmed=True
+        )  # デバイス(OTP)を作成
+
+    def test_verify_otp_view_get(self):
+        """OTP確認ページが正しいテンプレートを使っていることを確認する"""
+        response = self.client.get(reverse("accounts:verify_otp"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "accounts/verify_otp.html")
+
+    def test_verify_otp_view_post_valid_otp(self):
+        """正しいOTPトークンでOTP確認が成功することを確認する"""
+        totp = TOTP(
+            key=self.device.bin_key,
+            step=self.device.step,
+            t0=self.device.t0,
+            digits=self.device.digits,
+        )
+        totp.time = time.time()
+        valid_token = totp.token()
+        response = self.client.post(
+            reverse("accounts:verify_otp"), {"otp_token": valid_token}
+        )
+        # self.assertRedirects(response, reverse("accounts:home")) # homeが未設定のため
+
+    def test_verify_otp_view_post_invalid_otp(self):
+        """間違ったOTPトークンでOTP確認が失敗することを確認する"""
+        response = self.client.post(
+            reverse("accounts:verify_otp"), {"otp_token": "123456"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "accounts/verify_otp.html")
+        form = response.context["form"]
+        self.assertFormError(form, "otp_token", "Invalid OTP")

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -5,3 +5,4 @@ isort
 django_otp
 qrcode
 Pillow
+pyotp


### PR DESCRIPTION
## OTP認証に対するテストを追加しました

今までのテストに加えて、

ログインページで
- OTPが有効な場合 -> OTP認証ページへ
- OTPが無効な場合 -> そのままログイン

OTP認証ページで
- OTP認証ページでOTPが正しい場合にログインできるか
- OTP認証ページでOTPが間違っている場合にエラーになるか

OTPのセットアップページで
- アクセス(GET)段階ではdeviceが作成されて無効であるか
- 確認ボタンを押したら(POST)deviceが作成されて有効になっているか

を確認するテストケースを追加しました。