### PR TITLE
[update] frontendをnginxで配信するように

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -14,6 +14,8 @@ services:
   db:
     volumes: !reset []
 
+  frontend: !reset []
+
   web:
     image: nginx
     container_name: web

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -17,16 +17,16 @@ services:
   frontend: !reset []
 
   web:
-    image: nginx
+    build:
+      context: .
+      dockerfile: ./nginx/Dockerfile
     container_name: web
-    # todo: volumeを無しに
-    volumes:
-    #   - ./web/static:/usr/share/nginx/html
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     ports:
       - "80:80"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+    command: ["nginx", "-g", "daemon off;"]
 
 include:
   - ./elk/elk-services.yml

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,12 +33,12 @@ services:
       - ./data/db:/var/lib/postgresql/data
     env_file: .env
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "dbuser", "-d", "djangodb" ]
+      test: ["CMD", "pg_isready", "-U", "dbuser", "-d", "djangodb"]
       interval: 30s
       timeout: 30s
       retries: 5
       start_period: 30s
-  
+
   frontend:
     image: node:latest
     container_name: frontend
@@ -58,7 +58,7 @@ services:
     ports:
       - "6379:6379"
     healthcheck:
-      test: [ "CMD", "redis-cli", "localhost", "ping" ]
+      test: ["CMD", "redis-cli", "localhost", "ping"]
       interval: 30s
       timeout: 30s
       retries: 5

--- a/frontend/app-config.js
+++ b/frontend/app-config.js
@@ -1,0 +1,12 @@
+let backendHost;
+
+const hostname = window?.location?.hostname;
+const port = window?.location?.port;
+
+if (hostname === "localhost" && port === 80) {
+  backendHost = "localhost:80/backend";
+} else {
+  backendHost = "localhost:8000";
+}
+
+export const API_ROOT = `${backendHost}`;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,5 +27,6 @@
       crossorigin="anonymous"
     ></script>
     <script type="module" src="/app.js"></script>
+    <script type="module" src="/app-config.js"></script>
   </body>
 </html>

--- a/frontend/views/pages/Gameplay.js
+++ b/frontend/views/pages/Gameplay.js
@@ -1,3 +1,5 @@
+import { API_ROOT } from "../../app-config.js";
+
 const Gameplay = {
 	render: async () => {
 		return `
@@ -38,7 +40,7 @@ const Gameplay = {
 		};
 
 		// Websocket
-		const url = "ws://" + "localhost:8000" + "/ws/gameplay/";
+		const url = `ws://${API_ROOT}/ws/gameplay/`;
 		window.ws = new WebSocket(url);
 		console.log(url + " WebSocket created");
 

--- a/frontend/views/pages/Login.js
+++ b/frontend/views/pages/Login.js
@@ -1,3 +1,5 @@
+import { API_ROOT } from "../../app-config.js";
+
 const Login = {
   render: async () => {
     return `<main
@@ -34,7 +36,7 @@ const Login = {
         let password = document.getElementById("id_password").value;
 
         const response = await fetch(
-          "http://localhost:8000/accounts/api/login/",
+          `http://${API_ROOT}/accounts/api/login/`,
           {
             method: "POST",
             headers: {

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx
+
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY ./frontend /static/

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,16 +11,17 @@ server {
     server_name 0.0.0.0;
 
     # プロキシ設定
-    # 実際はNginxのコンテナにアクセスしてるのをDjangoにアクセスしてるかのようにみせる
+    # frontendの静的ファイル(HTML、CSS、Javascriptなど)を管理
     location / {
+		alias /static/;
+	}
+
+    # 実際はNginxのコンテナにアクセスしてるのをDjangoにアクセスしてるかのようにみせる
+    # backend apiへの直接のアクセス
+    location /api/ {
         proxy_pass http://django;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_redirect off;
     }
-    
-    # djangoの静的ファイル(HTML、CSS、Javascriptなど)を管理
-    # location /static/ {
-	# 	alias /static/;
-	# }
 }


### PR DESCRIPTION
## prod環境ではfrontendファイルををnginxで配信するようにしました

**#84 マージ後にマージ**

- prod環境ではfrontend serverを起動しないように
- Nginxの設定を整え、localhost:80からサイトを表示できるようにしました
- javascriptのfetchのurlも環境によって変わるように設定し、ルーティング処理がうまくいくようにしました

### USAGE
```
docker compose -f compose.yaml -f compose.prod.yaml up --build
```
でprod環境の http://localhost:80/ からページにアクセスできると思います

### TIPS
- 独立した環境で動かすという保守性の観点からprodではvolumeを使っていません