### PR TITLE
add: 追加でページ間のローテーションができるようにしました。

### DIFF
--- a/backend/gameplay/templates/gameplay/playpage.html
+++ b/backend/gameplay/templates/gameplay/playpage.html
@@ -17,9 +17,9 @@
   <title>gameplay</title>
 </head>
 
-
 <body>
   <canvas id="gameCanvas"></canvas>
+
   <script>
     const gameCanvas = document.getElementById("gameCanvas");
     const ctx = gameCanvas.getContext("2d");
@@ -55,8 +55,8 @@
     };
 
     const keyStates = { left: false, right: false };
-
     let animationFrameId;
+    let gameEnded = false;
 
     document.addEventListener("DOMContentLoaded", function () {
       // websocketの接続先
@@ -89,10 +89,25 @@
         paddle.right_y = data.right_paddle_y;
         ball.x = data.ball_x;
         ball.y = data.ball_y;
+
+        /* らざ追記：15点の点数判定を入れました。また、今は名前がわからないので、right,leftにしてますが、
+            DBから受信できるようになったら、対戦者の名前が表示されるようにしたいです。*/
+        if (!gameEnded && (score.left >= 15 || score.right >= 15)) {
+          gameEnded = true;
+          const winner = score.left >= 15 ? "left" : "right";
+          // Socketを閉じる→他にやることがあれば教えてください。
+          ws.close();
+          // 勝者ページにリダイレクト
+          window.location.href = `/result/winner/${winner}`;
+        }
       };
 
+
+      // らざ追記：gameendedつまりゲームが終わっていなければメッセージの送信をする仕様に変更
       function sendMessage(message) {
-        ws.send(JSON.stringify(message));
+        if (!gameEnded) {
+          ws.send(JSON.stringify(message));
+        }
       }
 
       // ボタンを長押ししたら送り続ける
@@ -130,7 +145,7 @@
           event.key === "D" ||
           event.key === "d"
         ) {
-          clearInterval(leftinterval); // メッセージ送信の間隔を止める
+          clearInterval(leftinterval);
           keyStates.left = false;
         } else if (
           event.key === "I" ||
@@ -138,44 +153,45 @@
           event.key === "K" ||
           event.key === "k"
         ) {
-          clearInterval(rightinterval); // メッセージ送信の間隔を止める
+          clearInterval(rightinterval);
           keyStates.right = false;
         }
       });
 
+      // らざ追記：gameendedつまりゲームが終わっていなければdrawを実行する。
       function draw() {
-        ctx.clearRect(0, 0, gameCanvas.width, gameCanvas.height);
-        // 背景描画
-        ctx.fillStyle = "black";
-        ctx.fillRect(0, 0, gameCanvas.width, gameCanvas.height);
-        ctx.strokeStyle = "white";
-        ctx.lineWidth = 5;
-        ctx.setLineDash([10, 10]);
+        if (!gameEnded) {
+          ctx.clearRect(0, 0, gameCanvas.width, gameCanvas.height);
+          // 背景描画
+          ctx.fillStyle = "black";
+          ctx.fillRect(0, 0, gameCanvas.width, gameCanvas.height);
+          ctx.strokeStyle = "white";
+          ctx.lineWidth = 5;
+          ctx.setLineDash([10, 10]);
 
-        ctx.beginPath();
-        ctx.moveTo(gameCanvas.width / 2, 0);
-        ctx.lineTo(gameCanvas.width / 2, gameCanvas.height);
-        ctx.stroke();
-        //スコア描画
-        ctx.font = `6vw "Press Start 2P", cursive`;
-        ctx.fillStyle = "white";
-        ctx.textBaseline = "top";
-        ctx.textAlign = "right"; // 右端を指定した座標に配置
-        ctx.fillText(score.left, l_score_x, score_y);
-        ctx.textAlign = "left";
-        ctx.fillText(score.right, r_score_x, score_y);
+          ctx.beginPath();
+          ctx.moveTo(gameCanvas.width / 2, 0);
+          ctx.lineTo(gameCanvas.width / 2, gameCanvas.height);
+          ctx.stroke();
+          //スコア描画
+          ctx.font = `6vw "Press Start 2P", cursive`;
+          ctx.fillStyle = "white";
+          ctx.textBaseline = "top";
+          ctx.textAlign = "right";
+          ctx.fillText(score.left, l_score_x, score_y);
+          ctx.textAlign = "left";
+          ctx.fillText(score.right, r_score_x, score_y);
 
-        //パドルとボール描画
-        ctx.fillRect(paddle.left_x, paddle.left_y, paddle_w, paddle_h);
-        ctx.fillRect(
-          paddle.right_x - paddle_w,
-          paddle.right_y,
-          paddle_w,
-          paddle_h
-        );
-        ctx.fillRect(ball.x - 10, ball.y - 10, 20, 20);
-
-        // 次の描画呼び出し
+          //パドルとボール描画
+          ctx.fillRect(paddle.left_x, paddle.left_y, paddle_w, paddle_h);
+          ctx.fillRect(
+            paddle.right_x - paddle_w,
+            paddle.right_y,
+            paddle_w,
+            paddle_h
+          );
+          ctx.fillRect(ball.x - 10, ball.y - 10, 20, 20);
+        }
         requestAnimationFrame(draw);
       }
     });

--- a/backend/resultpage/templates/resultpage/winner.html
+++ b/backend/resultpage/templates/resultpage/winner.html
@@ -39,8 +39,8 @@
             <div class="winner-text">
                 Winner: {{ username }}
             </div>
-            <a href="{% url 'gameplay:gameplay' %}" class="btn btn-primary">
-                トップページに戻る
+            <a href="{% url 'tournament:matches' %}" class="btn btn-primary">
+                次の試合情報へ
             </a>
         </div>
     </div>


### PR DESCRIPTION
Issueのところにも書きました。
概ね完成したと思います。

gamapleyに試合が15点に達したら、リダイレクトでresultのページが出るようにしたました。
resultページには**「次の試合情報へ」**ボタンを追加しました。
押すとtournament/matchesページに移動できるようにする。
tournament/matchesページで次の対戦相手を確認して、「ゲーム開始」ボタンを押す
gamaplayに辿り着く
上記の使用で完成しました。
gameplayの変更が気になると思います。

全ての変更した部分に対して「らざの追記」というコメントを入れています。
Global変数としてGameEndedを作って、ゲームが終了したかどうかを判定しています。
sendMessage, drawの関数にif文でGameEndedの判定を入れて、Falseなら関数の実行をします。
点数で判定

15点という点数で条件分岐を記入(93-103)
websocketを閉じるということについては気をつけました。他にもやることがあれば教えてください。
勝者の名前はDBから値を取得して最終的にはやりたいと思っています。現在は単純にright,leftにしています。
リダイレクトで/result/winner/${winner}に飛ばしています。
[https://www.w3schools.com/howto/howto_js_redirect_webpage.asp]
次のpushがこの内容を反映しています。