### PR TITLE
[update] Navbarレンダリングを最適化

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -36,4 +36,4 @@ window.addEventListener("hashchange", router);
 
 window.addEventListener("load", router);
 
-window.addEventListener("DOMContentLoad", Navbar.setTranslateHook());
+window.addEventListener("DOMContentLoaded", Navbar.setTranslateHook());

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -16,8 +16,6 @@ const router = async () => {
   const body = null || document.getElementById("body_container");
   const footer = null || document.getElementById("footer_container");
 
-  header.innerHTML = await Navbar.render();
-  await Navbar.after_render();
   // footer
 
   const location = window.location.hash.slice(1).toLowerCase() || "/";
@@ -37,3 +35,5 @@ const router = async () => {
 window.addEventListener("hashchange", router);
 
 window.addEventListener("load", router);
+
+window.addEventListener("DOMContentLoad", Navbar.setTranslateHook());

--- a/frontend/views/components/Navbar.js
+++ b/frontend/views/components/Navbar.js
@@ -53,9 +53,6 @@ const Navbar = {
             </nav>`;
   },
   after_render: async () => {
-    const lang = localStorage.getItem("lang") || "en";
-    await changeLanguage(lang);
-
     document.getElementById('change_to_english').addEventListener('click', (event) => {
         event.preventDefault();  // ページ遷移を防ぐ
         changeLanguage('en');

--- a/frontend/views/components/Navbar.js
+++ b/frontend/views/components/Navbar.js
@@ -1,59 +1,60 @@
 import { changeLanguage } from "../../utils/i18n.js";
 
 const Navbar = {
-  // render: async () => {
-  //   return `<nav class="navbar navbar-expand-lg bg-body-tertiary">
-  //               <div class="container-fluid">
-  //                   <a class="navbar-brand" href="#" data-i18n="navbar:navbar">Navbar</a>
-  //                   <button
-  //                   class="navbar-toggler"
-  //                   type="button"
-  //                   data-bs-toggle="collapse"
-  //                   data-bs-target="#navbarNav"
-  //                   aria-controls="navbarNav"
-  //                   aria-expanded="false"
-  //                   aria-label="Toggle navigation"
-  //                   >
-  //                   <span class="navbar-toggler-icon"></span>
-  //                   </button>
-  //                   <div class="collapse navbar-collapse" id="navbarNav">
-  //                   <ul class="navbar-nav">
-  //                       <li class="nav-item">
-  //                       <a class="nav-link active" href="#/" data-i18n="navbar:home">Home</a>
-  //                       </li>
-  //                       <li class="nav-item">
-  //                       <a class="nav-link active" href="#/gameplay" data-i18n="navbar:gameplay">Gameplay</a>
-  //                       </li>
-  //                       <li class="nav-item">
-  //                       <a class="nav-link" href="#/tournament" data-i18n="navbar:tournament">Tournament</a>
-  //                       </li>
-  //                       <li class="nav-item">
-  //                       <a class="nav-link" href="#/setup-otp" data-i18n="navbar:setupotp">Setup Otp</a>
-  //                       </li>
-  //                       <li class="nav-item">
-  //                       <a class="nav-link" href="#/mypage" data-i18n="navbar:mypage">My Page</a>
-  //                       </li>
-  //                   </ul>
-  //                   <ul class="navbar-nav ms-auto">
-  //                       <li class="nav-item dropdown">
-  //                       <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" data-i18n="navbar:language">
-  //                           Language
-  //                       </a>
-  //                       <ul class="dropdown-menu dropdown-menu-start" aria-labelledby="languageDropdown">
-  //                           <li><a class="dropdown-item" href="#" id="change_to_english" data-i18n="navbar:english">English</a></li>
-  //                           <li><a class="dropdown-item" href="#" id="change_to_japanese" data-i18n="navbar:japanese">Japanese</a></li>
-  //                           <li><a class="dropdown-item" href="#" id="change_to_chinese" data-i18n="navbar:chinese">Chinese</a></li>
-  //                       </ul>
-  //                       </li>
-  //                       <li class="nav-item">
-  //                           <a class="nav-link" href="#/login" data-i18n="navbar:login">Login</a>
-  //                       </li>
-  //                   </ul>
-  //               </div>
-  //           </nav>`;
-  // },
+  render: async () => {
+    return `<nav class="navbar navbar-expand-lg bg-body-tertiary">
+                <div class="container-fluid">
+                    <a class="navbar-brand" href="#" data-i18n="navbar:navbar">Navbar</a>
+                    <button
+                    class="navbar-toggler"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#navbarNav"
+                    aria-controls="navbarNav"
+                    aria-expanded="false"
+                    aria-label="Toggle navigation"
+                    >
+                    <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarNav">
+                    <ul class="navbar-nav">
+                        <li class="nav-item">
+                        <a class="nav-link active" href="#/" data-i18n="navbar:home">Home</a>
+                        </li>
+                        <li class="nav-item">
+                        <a class="nav-link active" href="#/gameplay" data-i18n="navbar:gameplay">Gameplay</a>
+                        </li>
+                        <li class="nav-item">
+                        <a class="nav-link" href="#/tournament" data-i18n="navbar:tournament">Tournament</a>
+                        </li>
+                        <li class="nav-item">
+                        <a class="nav-link" href="#/setup-otp" data-i18n="navbar:setupotp">Setup Otp</a>
+                        </li>
+                        <li class="nav-item">
+                        <a class="nav-link" href="#/mypage" data-i18n="navbar:mypage">My Page</a>
+                        </li>
+                    </ul>
+                    <ul class="navbar-nav ms-auto">
+                        <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" data-i18n="navbar:language">
+                            Language
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-start" aria-labelledby="languageDropdown">
+                            <li><a class="dropdown-item" href="#" id="change_to_english" data-i18n="navbar:english">English</a></li>
+                            <li><a class="dropdown-item" href="#" id="change_to_japanese" data-i18n="navbar:japanese">Japanese</a></li>
+                            <li><a class="dropdown-item" href="#" id="change_to_chinese" data-i18n="navbar:chinese">Chinese</a></li>
+                        </ul>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#/login" data-i18n="navbar:login">Login</a>
+                        </li>
+                    </ul>
+                </div>
+            </nav>`;
+  },
 
-  after_render: async () => {},
+  after_render: async () => {
+  },
 
   setTranslateHook: async () => {
     document.getElementById('change_to_english').addEventListener('click', (event) => {

--- a/frontend/views/components/Navbar.js
+++ b/frontend/views/components/Navbar.js
@@ -1,71 +1,74 @@
 import { changeLanguage } from "../../utils/i18n.js";
 
 const Navbar = {
-  render: async () => {
-    return `<nav class="navbar navbar-expand-lg bg-body-tertiary">
-                <div class="container-fluid">
-                    <a class="navbar-brand" href="#" data-i18n="navbar:navbar">Navbar</a>
-                    <button
-                    class="navbar-toggler"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#navbarNav"
-                    aria-controls="navbarNav"
-                    aria-expanded="false"
-                    aria-label="Toggle navigation"
-                    >
-                    <span class="navbar-toggler-icon"></span>
-                    </button>
-                    <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item">
-                        <a class="nav-link active" href="#/" data-i18n="navbar:home">Home</a>
-                        </li>
-                        <li class="nav-item">
-                        <a class="nav-link active" href="#/gameplay" data-i18n="navbar:gameplay">Gameplay</a>
-                        </li>
-                        <li class="nav-item">
-                        <a class="nav-link" href="#/tournament" data-i18n="navbar:tournament">Tournament</a>
-                        </li>
-                        <li class="nav-item">
-                        <a class="nav-link" href="#/setup-otp" data-i18n="navbar:setupotp">Setup Otp</a>
-                        </li>
-                        <li class="nav-item">
-                        <a class="nav-link" href="#/mypage" data-i18n="navbar:mypage">My Page</a>
-                        </li>
-                    </ul>
-                    <ul class="navbar-nav ms-auto">
-                        <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" data-i18n="navbar:language">
-                            Language
-                        </a>
-                        <ul class="dropdown-menu dropdown-menu-start" aria-labelledby="languageDropdown">
-                            <li><a class="dropdown-item" href="#" id="change_to_english" data-i18n="navbar:english">English</a></li>
-                            <li><a class="dropdown-item" href="#" id="change_to_japanese" data-i18n="navbar:japanese">Japanese</a></li>
-                            <li><a class="dropdown-item" href="#" id="change_to_chinese" data-i18n="navbar:chinese">Chinese</a></li>
-                        </ul>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="#/login" data-i18n="navbar:login">Login</a>
-                        </li>
-                    </ul>
-                </div>
-            </nav>`;
-  },
-  after_render: async () => {
+  // render: async () => {
+  //   return `<nav class="navbar navbar-expand-lg bg-body-tertiary">
+  //               <div class="container-fluid">
+  //                   <a class="navbar-brand" href="#" data-i18n="navbar:navbar">Navbar</a>
+  //                   <button
+  //                   class="navbar-toggler"
+  //                   type="button"
+  //                   data-bs-toggle="collapse"
+  //                   data-bs-target="#navbarNav"
+  //                   aria-controls="navbarNav"
+  //                   aria-expanded="false"
+  //                   aria-label="Toggle navigation"
+  //                   >
+  //                   <span class="navbar-toggler-icon"></span>
+  //                   </button>
+  //                   <div class="collapse navbar-collapse" id="navbarNav">
+  //                   <ul class="navbar-nav">
+  //                       <li class="nav-item">
+  //                       <a class="nav-link active" href="#/" data-i18n="navbar:home">Home</a>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                       <a class="nav-link active" href="#/gameplay" data-i18n="navbar:gameplay">Gameplay</a>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                       <a class="nav-link" href="#/tournament" data-i18n="navbar:tournament">Tournament</a>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                       <a class="nav-link" href="#/setup-otp" data-i18n="navbar:setupotp">Setup Otp</a>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                       <a class="nav-link" href="#/mypage" data-i18n="navbar:mypage">My Page</a>
+  //                       </li>
+  //                   </ul>
+  //                   <ul class="navbar-nav ms-auto">
+  //                       <li class="nav-item dropdown">
+  //                       <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" data-i18n="navbar:language">
+  //                           Language
+  //                       </a>
+  //                       <ul class="dropdown-menu dropdown-menu-start" aria-labelledby="languageDropdown">
+  //                           <li><a class="dropdown-item" href="#" id="change_to_english" data-i18n="navbar:english">English</a></li>
+  //                           <li><a class="dropdown-item" href="#" id="change_to_japanese" data-i18n="navbar:japanese">Japanese</a></li>
+  //                           <li><a class="dropdown-item" href="#" id="change_to_chinese" data-i18n="navbar:chinese">Chinese</a></li>
+  //                       </ul>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                           <a class="nav-link" href="#/login" data-i18n="navbar:login">Login</a>
+  //                       </li>
+  //                   </ul>
+  //               </div>
+  //           </nav>`;
+  // },
+
+  after_render: async () => {},
+
+  setTranslateHook: async () => {
     document.getElementById('change_to_english').addEventListener('click', (event) => {
-        event.preventDefault();  // ページ遷移を防ぐ
-        changeLanguage('en');
-      });
-      document.getElementById('change_to_japanese').addEventListener('click', (event) => {
-        event.preventDefault();
-        changeLanguage('ja');
-      });
-      document.getElementById('change_to_chinese').addEventListener('click', (event) => {
-        event.preventDefault();
-        changeLanguage('zh');
-      });
-  },
+      event.preventDefault();  // ページ遷移を防ぐ
+      changeLanguage('en');
+    });
+    document.getElementById('change_to_japanese').addEventListener('click', (event) => {
+      event.preventDefault();
+      changeLanguage('ja');
+    });
+    document.getElementById('change_to_chinese').addEventListener('click', (event) => {
+      event.preventDefault();
+      changeLanguage('zh');
+    });
+  }
 };
 
 export default Navbar;

--- a/frontend/views/components/Navbar.js
+++ b/frontend/views/components/Navbar.js
@@ -1,57 +1,57 @@
 import { changeLanguage } from "../../utils/i18n.js";
 
 const Navbar = {
-  render: async () => {
-    return `<nav class="navbar navbar-expand-lg bg-body-tertiary">
-                <div class="container-fluid">
-                    <a class="navbar-brand" href="#" data-i18n="navbar:navbar">Navbar</a>
-                    <button
-                    class="navbar-toggler"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#navbarNav"
-                    aria-controls="navbarNav"
-                    aria-expanded="false"
-                    aria-label="Toggle navigation"
-                    >
-                    <span class="navbar-toggler-icon"></span>
-                    </button>
-                    <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav">
-                        <li class="nav-item">
-                        <a class="nav-link active" href="#/" data-i18n="navbar:home">Home</a>
-                        </li>
-                        <li class="nav-item">
-                        <a class="nav-link active" href="#/gameplay" data-i18n="navbar:gameplay">Gameplay</a>
-                        </li>
-                        <li class="nav-item">
-                        <a class="nav-link" href="#/tournament" data-i18n="navbar:tournament">Tournament</a>
-                        </li>
-                        <li class="nav-item">
-                        <a class="nav-link" href="#/setup-otp" data-i18n="navbar:setupotp">Setup Otp</a>
-                        </li>
-                        <li class="nav-item">
-                        <a class="nav-link" href="#/mypage" data-i18n="navbar:mypage">My Page</a>
-                        </li>
-                    </ul>
-                    <ul class="navbar-nav ms-auto">
-                        <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" data-i18n="navbar:language">
-                            Language
-                        </a>
-                        <ul class="dropdown-menu dropdown-menu-start" aria-labelledby="languageDropdown">
-                            <li><a class="dropdown-item" href="#" id="change_to_english" data-i18n="navbar:english">English</a></li>
-                            <li><a class="dropdown-item" href="#" id="change_to_japanese" data-i18n="navbar:japanese">Japanese</a></li>
-                            <li><a class="dropdown-item" href="#" id="change_to_chinese" data-i18n="navbar:chinese">Chinese</a></li>
-                        </ul>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="#/login" data-i18n="navbar:login">Login</a>
-                        </li>
-                    </ul>
-                </div>
-            </nav>`;
-  },
+  // render: async () => {
+  //   return `<nav class="navbar navbar-expand-lg bg-body-tertiary">
+  //               <div class="container-fluid">
+  //                   <a class="navbar-brand" href="#" data-i18n="navbar:navbar">Navbar</a>
+  //                   <button
+  //                   class="navbar-toggler"
+  //                   type="button"
+  //                   data-bs-toggle="collapse"
+  //                   data-bs-target="#navbarNav"
+  //                   aria-controls="navbarNav"
+  //                   aria-expanded="false"
+  //                   aria-label="Toggle navigation"
+  //                   >
+  //                   <span class="navbar-toggler-icon"></span>
+  //                   </button>
+  //                   <div class="collapse navbar-collapse" id="navbarNav">
+  //                   <ul class="navbar-nav">
+  //                       <li class="nav-item">
+  //                       <a class="nav-link active" href="#/" data-i18n="navbar:home">Home</a>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                       <a class="nav-link active" href="#/gameplay" data-i18n="navbar:gameplay">Gameplay</a>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                       <a class="nav-link" href="#/tournament" data-i18n="navbar:tournament">Tournament</a>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                       <a class="nav-link" href="#/setup-otp" data-i18n="navbar:setupotp">Setup Otp</a>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                       <a class="nav-link" href="#/mypage" data-i18n="navbar:mypage">My Page</a>
+  //                       </li>
+  //                   </ul>
+  //                   <ul class="navbar-nav ms-auto">
+  //                       <li class="nav-item dropdown">
+  //                       <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" data-i18n="navbar:language">
+  //                           Language
+  //                       </a>
+  //                       <ul class="dropdown-menu dropdown-menu-start" aria-labelledby="languageDropdown">
+  //                           <li><a class="dropdown-item" href="#" id="change_to_english" data-i18n="navbar:english">English</a></li>
+  //                           <li><a class="dropdown-item" href="#" id="change_to_japanese" data-i18n="navbar:japanese">Japanese</a></li>
+  //                           <li><a class="dropdown-item" href="#" id="change_to_chinese" data-i18n="navbar:chinese">Chinese</a></li>
+  //                       </ul>
+  //                       </li>
+  //                       <li class="nav-item">
+  //                           <a class="nav-link" href="#/login" data-i18n="navbar:login">Login</a>
+  //                       </li>
+  //                   </ul>
+  //               </div>
+  //           </nav>`;
+  // },
 
   after_render: async () => {
   },


### PR DESCRIPTION
#99 -> #100 の順にmergeをお願いします。

**説明**
Navbarレンダリングを最適化しました。

今まではSSRでNavbarがレンダリングされた後、各urlに移動するたびにNavbarを再レンダリングし翻訳ボタンのhook設定が重ねて行われていました。(Navbarのrenderとafter_renderをrouterから毎回呼んでいた)
そもそもNavbarはSSRでレンダリングされた後アプリにずっと存在するので、レンダリングの部分をブラウザが持つ必要がない。よって今回はrenderをコメントアウト(以後必要になった時のため)し、ページの初回ロード時に1度だけ翻訳ボタンhookを設定するようにしました。

**確認方法**
```
docker-compose up
```
した後、
```
http://localhost:3000/
```
にアクセスしてください。
Homeにいる状態から画面をwindowのどちらかに寄せることでNavbarを縦に広げてから、mypageを押してください。
Navbarが閉じないことが確認できると思います。(修正前のmainブランチなどで同じことをすると再レンダリングしているのでNavbarが閉じる)

翻訳ボタンのhook設定が重複して行われていないことはコードを読んでいただければ分かると思います。(/frontend/app.jsで一度のみsetTranslateHook()が呼ばれていて、他では呼ばれていない)

**余談**
Navbarが再レンダリングされていないことを確かめる少し複雑な方法を見つけたので、MTG時にお伝えします。