### PR TITLE
[add] JWT認証を追加

### DIFF
--- a/backend/accounts/utils/auth.py
+++ b/backend/accounts/utils/auth.py
@@ -1,0 +1,53 @@
+import time
+
+import jwt
+from rest_framework import exceptions
+from rest_framework.authentication import (BaseAuthentication,
+                                           get_authorization_header)
+
+from accounts.models import CustomUser
+from core.settings import SECRET_KEY
+
+
+def generate_jwt(user):
+    timestamp = int(time.time()) + 60 * 60 * 24 * 7
+    return jwt.encode(
+        {
+            "userid": user.pk,
+            "username": user.username,
+            "email": user.email,
+            "exp": timestamp,
+        },
+        SECRET_KEY,
+    )
+
+
+class JWTAuthentication(BaseAuthentication):
+    keyword = "JWT"
+    model = None
+
+    def authenticate(self, request):
+        auth = get_authorization_header(request).split()
+
+        if not auth or auth[0].lower() != self.keyword.lower().encode():
+            return None
+
+        if len(auth) == 1:
+            raise exceptions.AuthenticationFailed("Invalid authorization")
+        elif len(auth) > 2:
+            raise exceptions.AuthenticationFailed("Invalid authorization no space")
+
+        try:
+            jwt_token = auth[1]
+            jwt_info = jwt.decode(jwt_token, SECRET_KEY, algorithms=["HS256"])
+            userid = jwt_info.get("userid")
+            try:
+                user = CustomUser.objects.get(pk=userid)
+                return (user, jwt_token)
+            except:
+                raise exceptions.AuthenticationFailed("User does not exist")
+        except jwt.ExpiredSignatureError:
+            raise exceptions.AuthenticationFailed("Token expired")
+
+    def authentication_header(self, request):
+        pass

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -6,11 +6,12 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .serializers import LoginSerializer, OTPSerializer, SignUpSerializer
-from .utils.auth import generate_jwt
+from .utils.auth import JWTAuthentication, generate_jwt
 
 
 @method_decorator([sensitive_post_parameters(), never_cache], name="dispatch")
@@ -49,8 +50,15 @@ class SignUpView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-@method_decorator([never_cache, login_required], name="dispatch")
+@method_decorator([never_cache], name="dispatch")
 class SetupOTPView(APIView):
+    authentication_classes = [
+        JWTAuthentication,
+    ]
+    permission_classes = [
+        IsAuthenticated,
+    ]
+
     def get(self, request):
         user = request.user
         if not TOTPDevice.objects.filter(user=user, confirmed=True).exists():

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .serializers import LoginSerializer, OTPSerializer, SignUpSerializer
+from .utils.auth import generate_jwt
 
 
 @method_decorator([sensitive_post_parameters(), never_cache], name="dispatch")
@@ -22,8 +23,11 @@ class CustomLoginView(APIView):
                 return Response(
                     {"redirect": "accounts:verify_otp"}, status=status.HTTP_200_OK
                 )
+            token = generate_jwt(user)
             login(request, user)
-            return Response({"redirect": "homepage"}, status=status.HTTP_200_OK)
+            return Response(
+                {"token": token, "redirect": "homepage"}, status=status.HTTP_200_OK
+            )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -209,7 +209,6 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 
 if ENVIRONMENT == "production":
     DEBUG = False
-    SECRET_KEY = os.getenv("SECRET_KEY")
     CSRF_COOKIE_SECURE = True
     SESSION_COOKIE_SECURE = True
     SECURE_BROWSER_XSS_FILTER = True

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -205,6 +205,8 @@ LOGGING = {
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
+SECRET_KEY = os.getenv("SECRET_KEY")
+
 if ENVIRONMENT == "production":
     DEBUG = False
     SECRET_KEY = os.getenv("SECRET_KEY")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ channels_redis
 daphne
 djangorestframework
 django-cors-headers
+pyjwt


### PR DESCRIPTION
## JWT認証を追加しました

バックエンドのみの追加になります

- ログインの際にJWTをpyjwtライブラリで生成して返すようにしました
- SetupOtp Viewに対してJWT認証がないとアクセスできないようにしました

## TEST
http://localhost:8000/accounts/api/login/ にアクセスして
```
{
"username": "admin",
"password": "admin"
}
```
をPOSTしてログインし、トークンを取得

```
curl -H "Authorization: JWT $TOKEN" http://localhost:8000/accounts/api/setup-otp/
```
でトークンを使用してSetupOtp Viewにアクセス(`$TOKEN`の部分は発行されたJWTを使用してください・トークンがないとアクセスできないことも確認できるかと思います)

## 参考
- https://qiita.com/Syoitu/items/bc32b5e1c2fa891c2f96