### PR TITLE
[update] ログインしたらナビバーの表示を変えるように

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -42,6 +42,12 @@ const router = async () => {
       loginButton.id = "navbar:logout";
       loginButton.textContent = "Logout";
     }
+
+    const setupOtpButton = document.getElementById("navbar:setup-otp");
+    if (setupOtpButton) {
+      setupOtpButton.setAttribute("href", "#/setup-otp");
+      setupOtpButton.classList.remove("disabled");
+    }
   }
 
   // footer

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,6 +2,7 @@
 
 import Navbar from "./views/components/Navbar.js";
 import Login from "./views/pages/Login.js";
+import Logout from "./views/pages/Logout.js";
 import SignUp from "./views/pages/SignUp.js";
 import SetupOtp from "./views/pages/SetUpOtp.js";
 import Home from "./views/pages/Home.js";
@@ -11,6 +12,7 @@ import Tournament from "./views/pages/Tournament.js";
 const routes = {
   "/": Home,
   "/login": Login,
+  "/logout": Logout,
   "/signup": SignUp,
   "/setup-otp": SetupOtp,
   "/gameplay": Gameplay,
@@ -22,8 +24,6 @@ const router = async () => {
   const body = null || document.getElementById("body_container");
   const footer = null || document.getElementById("footer_container");
 
-  // footer
-
   const location = window.location.hash.slice(1).toLowerCase() || "/";
   console.log(location);
 
@@ -33,6 +33,18 @@ const router = async () => {
 
   const page = routes[location];
   window.currentPage = page;
+
+  if (sessionStorage.getItem("is_logged_in") === "true") {
+    const loginButton = document.getElementById("navbar:login");
+    if (loginButton) {
+      loginButton.setAttribute("href", "#/logout");
+      loginButton.setAttribute("data-i18n", "navbar:logout");
+      loginButton.id = "navbar:logout";
+      loginButton.textContent = "Logout";
+    }
+  }
+
+  // footer
 
   body.innerHTML = await page.render();
   await page.after_render();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -34,7 +34,7 @@ const router = async () => {
   const page = routes[location];
   window.currentPage = page;
 
-  if (sessionStorage.getItem("is_logged_in") === "true") {
+  if (document.cookie.includes("is_logged_in=true")) {
     const loginButton = document.getElementById("navbar:login");
     if (loginButton) {
       loginButton.setAttribute("href", "#/logout");

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -19,6 +19,16 @@ const routes = {
   "/tournament": Tournament,
 };
 
+const getCookie = (name) => {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    const val = parts.pop().split(";").shift();
+    return val && val.length > 0 ? val : null;
+  }
+  return null;
+};
+
 const router = async () => {
   const header = null || document.getElementById("header_container");
   const body = null || document.getElementById("body_container");
@@ -34,7 +44,7 @@ const router = async () => {
   const page = routes[location];
   window.currentPage = page;
 
-  if (document.cookie.includes("is_logged_in=true")) {
+  if (getCookie("token")) {
     const loginButton = document.getElementById("navbar:login");
     if (loginButton) {
       loginButton.setAttribute("href", "#/logout");
@@ -42,11 +52,12 @@ const router = async () => {
       loginButton.id = "navbar:logout";
       loginButton.textContent = "Logout";
     }
-
-    const setupOtpButton = document.getElementById("navbar:setup-otp");
-    if (setupOtpButton) {
-      setupOtpButton.setAttribute("href", "#/setup-otp");
-      setupOtpButton.classList.remove("disabled");
+    if (getCookie("token") != "dummy") {
+      const setupOtpButton = document.getElementById("navbar:setup-otp");
+      if (setupOtpButton) {
+        setupOtpButton.setAttribute("href", "#/setup-otp");
+        setupOtpButton.classList.remove("disabled");
+      }
     }
   }
 

--- a/frontend/utils/locales/en/navbar.json
+++ b/frontend/utils/locales/en/navbar.json
@@ -7,6 +7,7 @@
 	"mypage": "My Page",
 	"gameplay": "Gameplay",
 	"login": "Login",
+    "logout": "Logout",
 	"language": "Language",
 	"english": "English",
 	"japanese": "Japanese",

--- a/frontend/utils/locales/ja/navbar.json
+++ b/frontend/utils/locales/ja/navbar.json
@@ -7,6 +7,7 @@
 	"mypage": "マイページ",
 	"gameplay": "ゲームプレイ",
 	"login": "ログイン",
+	"logout": "ログアウト",
 	"language": "言語",
 	"english": "英語",
 	"japanese": "日本語",

--- a/frontend/utils/locales/zh/navbar.json
+++ b/frontend/utils/locales/zh/navbar.json
@@ -7,6 +7,7 @@
 	"mypage": "我的页面",
 	"gameplay": "游戏玩法",
 	"login": "登录",
+	"logout": "登出",
 	"language": "语言",
 	"english": "英语",
 	"japanese": "日语",

--- a/frontend/views/pages/Login.js
+++ b/frontend/views/pages/Login.js
@@ -41,6 +41,7 @@ const Login = {
         if (response.ok) {
           console.log("Login success: ", data);
           sessionStorage.setItem("token", data.token);
+          sessionStorage.setItem("is_logged_in", "true");
           window.location.hash = "#/";
         } else {
           const errors = Object.entries(data)
@@ -60,6 +61,7 @@ const Login = {
       .addEventListener("click", async (event) => {
         event.preventDefault();
         window.location.href = `${window.env.BACKEND_HOST}/oauth/`;
+        sessionStorage.setItem("is_logged_in", "true");
       });
 
     document

--- a/frontend/views/pages/Login.js
+++ b/frontend/views/pages/Login.js
@@ -41,7 +41,6 @@ const Login = {
         if (response.ok) {
           console.log("Login success: ", data);
           document.cookie = `token=${data.token}; path=/; Secure; SameSite=Strict; max-age=86400`;
-          document.cookie = `is_logged_in=true; path=/; Secure; SameSite=Strict; max-age=86400`;
           window.location.hash = "#/";
         } else {
           const errors = Object.entries(data)
@@ -61,7 +60,7 @@ const Login = {
       .addEventListener("click", async (event) => {
         event.preventDefault();
         window.location.href = `${window.env.BACKEND_HOST}/oauth/`;
-        document.cookie = `is_logged_in=true; path=/; Secure; SameSite=Strict; max-age=86400`;
+        document.cookie = `token=dummy; path=/; Secure; SameSite=Strict; max-age=86400`;
       });
 
     document

--- a/frontend/views/pages/Login.js
+++ b/frontend/views/pages/Login.js
@@ -40,8 +40,8 @@ const Login = {
 
         if (response.ok) {
           console.log("Login success: ", data);
-          sessionStorage.setItem("token", data.token);
-          sessionStorage.setItem("is_logged_in", "true");
+          document.cookie = `token=${data.token}; path=/; Secure; SameSite=Strict; max-age=86400`;
+          document.cookie = `is_logged_in=true; path=/; Secure; SameSite=Strict; max-age=86400`;
           window.location.hash = "#/";
         } else {
           const errors = Object.entries(data)
@@ -61,7 +61,7 @@ const Login = {
       .addEventListener("click", async (event) => {
         event.preventDefault();
         window.location.href = `${window.env.BACKEND_HOST}/oauth/`;
-        sessionStorage.setItem("is_logged_in", "true");
+        document.cookie = `is_logged_in=true; path=/; Secure; SameSite=Strict; max-age=86400`;
       });
 
     document

--- a/frontend/views/pages/Logout.js
+++ b/frontend/views/pages/Logout.js
@@ -1,0 +1,27 @@
+const Logout = {
+  render: async () => {
+    try {
+      sessionStorage.removeItem("token");
+      sessionStorage.removeItem("is_logged_in");
+    } catch (error) {
+      console.error("Failed to clear session storage:", error);
+      alert("An error occurred during logout process");
+      return;
+    }
+
+    return (await fetch("/views/templates/Logout.html")).text();
+  },
+
+  after_render: async () => {
+    const logoutButton = document.getElementById("navbar:logout");
+    console.log(logoutButton)
+    if (logoutButton) {
+      logoutButton.setAttribute("href", "#/login");
+      logoutButton.setAttribute("data-i18n", "navbar:login");
+      logoutButton.id = "navbar:login";
+      logoutButton.textContent = "Login";
+    }
+  },
+};
+
+export default Logout;

--- a/frontend/views/pages/Logout.js
+++ b/frontend/views/pages/Logout.js
@@ -2,8 +2,6 @@ const Logout = {
   render: async () => {
     try {
       document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
-      document.cookie =
-        "is_logged_in=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
     } catch (error) {
       console.error("Failed to clear cookies:", error);
       alert("An error occurred during logout process");

--- a/frontend/views/pages/Logout.js
+++ b/frontend/views/pages/Logout.js
@@ -14,12 +14,17 @@ const Logout = {
 
   after_render: async () => {
     const logoutButton = document.getElementById("navbar:logout");
-    console.log(logoutButton)
     if (logoutButton) {
       logoutButton.setAttribute("href", "#/login");
       logoutButton.setAttribute("data-i18n", "navbar:login");
       logoutButton.id = "navbar:login";
       logoutButton.textContent = "Login";
+    }
+
+    const setupOtpButton = document.getElementById("navbar:setup-otp");
+    if (setupOtpButton) {
+      setupOtpButton.removeAttribute("href");
+      setupOtpButton.classList.add("disabled");
     }
   },
 };

--- a/frontend/views/pages/Logout.js
+++ b/frontend/views/pages/Logout.js
@@ -1,10 +1,11 @@
 const Logout = {
   render: async () => {
     try {
-      sessionStorage.removeItem("token");
-      sessionStorage.removeItem("is_logged_in");
+      document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+      document.cookie =
+        "is_logged_in=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
     } catch (error) {
-      console.error("Failed to clear session storage:", error);
+      console.error("Failed to clear cookies:", error);
       alert("An error occurred during logout process");
       return;
     }

--- a/frontend/views/pages/SetupOtp.js
+++ b/frontend/views/pages/SetupOtp.js
@@ -4,15 +4,20 @@ const SetupOtp = {
       (response) => response.text()
     );
 
+    const token = document.cookie.replace(
+      /(?:(?:^|.*;\s*)token\s*\=\s*([^;]*).*$)|^.*$/,
+      "$1"
+    );
+
     const response = await fetch(
       `${window.env.BACKEND_HOST}/accounts/api/setup-otp/`,
       {
         method: "GET",
         headers: {
-          Authorization: `JWT ${sessionStorage.getItem("token")}`,
+          Authorization: `JWT ${token}`,
         },
       }
-    );
+    ).catch((error) => console.error(error));
     const data = await response.json();
 
     console.log(data);
@@ -33,12 +38,17 @@ const SetupOtp = {
         e.preventDefault();
 
         try {
+          const token = document.cookie.replace(
+            /(?:(?:^|.*;\s*)token\s*\=\s*([^;]*).*$)|^.*$/,
+            "$1"
+          );
+
           const response = await fetch(
             `${window.env.BACKEND_HOST}/accounts/api/setup-otp/`,
             {
               method: "POST",
               headers: {
-                Authorization: `JWT ${sessionStorage.getItem("token")}`,
+                Authorization: `JWT ${token}`,
                 "Content-Type": "application/json",
               },
             }

--- a/frontend/views/templates/Logout.html
+++ b/frontend/views/templates/Logout.html
@@ -1,0 +1,5 @@
+<div class="text-center mt-5">
+  <h1>Successfully Logged Out</h1>
+  <p>Thank you for using our service</p>
+  <a href="#/" class="btn btn-outline-primary btn-lg">Return to Home Page</a>
+</div>

--- a/frontend/views/templates/Navbar.html
+++ b/frontend/views/templates/Navbar.html
@@ -36,7 +36,7 @@
           </ul>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#/login" data-i18n="navbar:login">Login</a>
+          <a class="nav-link" href="#/login" data-i18n="navbar:login" id="navbar:login">Login</a>
         </li>
       </ul>
     </div>

--- a/frontend/views/templates/Navbar.html
+++ b/frontend/views/templates/Navbar.html
@@ -14,10 +14,10 @@
           <a class="nav-link" href="#/tournament" data-i18n="navbar:tournament">Tournament</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#/setup-otp" data-i18n="navbar:setupotp">Setup Otp</a>
+          <a class="nav-link disabled" data-i18n="navbar:setupotp" id="navbar:setup-otp">Setup Otp</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#/mypage" data-i18n="navbar:mypage">My Page</a>
+          <a class="nav-link disabled" data-i18n="navbar:mypage">My Page</a>
         </li>
       </ul>
       <ul class="navbar-nav ms-auto">


### PR DESCRIPTION
## ログインしたらナビバーの表示を変えるようにしました

**[rin/120-add-otp-setup-page](https://github.com/ft-transcendence-project/42-transcendence/tree/rin/120-add-otp-setup-page)** マージ後にマージ

- ログイン前はナビバーのSetupOtpとMyPageのリンクを無効に
- ログイン後はSetupOtpのリンクを有効にしてLoginボタンをLogoutボタンに
- ログアウトしたら設定をリセット
- 42Oauthでログインした場合にはOtpをセットできないように

### IMPLEMENT
`document.getElementById`を使って要素を取得
-> `setAttribute`や`removeAttribute`を使って属性を追加したり、`classList`を使ってクラスの操作を行っていたりしています

JWTの管理方法を`sessionStorage`から`cookie`に変更
-> ログインした状態で別のタブでアクセスしてもログインしたままに

### TIPS

- https://zenn.dev/simsim/articles/3f3e043dd750e8
- https://qiita.com/hazure_engineer/items/68cc9b97c3d5f72567ef

#### データ保存方法の選択肢

#### 1. ブラウザストレージ
1. **localStorage**
```javascript


localStorage.setItem('token', data.token);
```

2. **sessionStorage**
```javascript
sessionStorage.setItem('token', data.token);
```

3. **Cookie**
```javascript
document.cookie = `token=${data.token}; path=/; HttpOnly; Secure; SameSite=Strict`;
```

4. **IndexedDB**
```javascript
const request = indexedDB.open("MyDatabase", 1);
request.onsuccess = (event) => {
  const db = event.target.result;
  const tx = db.transaction('tokens', 'readwrite');
  const store = tx.objectStore('tokens');
  store.put(data.token, 'userToken');
};
```

#### 2. ネイティブストレージ
1. **WebSQL**（非推奨）
2. **File System API**（制限付き）

#### 推奨度
1. セキュアなデータ → HttpOnly Cookie
2. 一時的なデータ → sessionStorage
3. 永続的なデータ → localStorage
4. 構造化データ → IndexedDB