### PR TITLE
[update] Oauth42を本番環境でも動くように修正

### DIFF
--- a/.env.prod_template
+++ b/.env.prod_template
@@ -1,0 +1,49 @@
+POSTGRES_DB=djangodb
+POSTGRES_NAME=djangodb
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+POSTGRES_USER=dbuser
+POSTGRES_PASSWORD=dbpassword
+
+# SECRET_KEY For Django
+SECRET_KEY=3yRtn3J7xMywl2TBf2cojDqo4NZIJ9H2lUXp5ThVGZwi1EMJ2Pkwki2vyFwk4Q2C
+
+# UID and SECRET for 42 OAuth2
+UID="u-s4t2ud-e61d81965a94d889b0a7daae8249b278b07cc9141ff3292ae27fbe0337bf6c90"
+SECRET="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"
+
+# Project namespace (defaults to the current folder name if not set)
+#COMPOSE_PROJECT_NAME=myproject
+
+# Password for the 'elastic' user (at least 6 characters)
+ELASTIC_PASSWORD=changeme
+
+# Password for the 'kibana_system' user (at least 6 characters)
+KIBANA_PASSWORD=changeme
+
+# Version of Elastic products
+STACK_VERSION=8.7.1
+
+# Set the cluster name
+CLUSTER_NAME=docker-cluster
+
+# Set to 'basic' or 'trial' to automatically start the 30-day trial
+LICENSE=basic
+#LICENSE=trial
+
+# Port to expose Elasticsearch HTTP API to the host
+ES_PORT=9200
+
+# Port to expose Kibana to the host
+KIBANA_PORT=5601
+
+# Increase or decrease based on the available host memory (in bytes)
+ES_MEM_LIMIT=1073741824
+KB_MEM_LIMIT=1073741824
+LS_MEM_LIMIT=1073741824
+
+# SAMPLE Predefined Key only to be used in POC environments
+ENCRYPTION_KEY=c34d38b3a14956121ff2170e5030b471551370178f43e5626eec58b04a30fae2
+
+# ganache-cli mnemonic
+MNEMONIC="myth like bonus scare over problem client lizard pioneer submit female collect"

--- a/.github/workflows/docker-compose-web-prod-test.yml
+++ b/.github/workflows/docker-compose-web-prod-test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and run Docker Compose
         run: |
-          mv .env_template .env
+          mv .env.prod_template .env
           docker compose -f compose.yaml -f compose.prod.yaml up -d --build
 
       - name: Wait for services to be healthy

--- a/.github/workflows/docker-compose-web-prod-test.yml
+++ b/.github/workflows/docker-compose-web-prod-test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and run Docker Compose
         run: |
-          mv .env.prod_template .env
+          mv .env.prod_template .env.prod
           docker compose -f compose.yaml -f compose.prod.yaml up -d --build
 
       - name: Wait for services to be healthy

--- a/.github/workflows/docker-compose-web-prod-test.yml
+++ b/.github/workflows/docker-compose-web-prod-test.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Wait for services to be healthy
         run: |
-          ./wait-for-it.sh localhost:443 --timeout=60 --strict -- echo "Web service is up"
+          ./wait-for-it.sh localhost:8443 --timeout=60 --strict -- echo "Web service is up"
 
       - name: Run Django tests
         run: |

--- a/.github/workflows/docker-compose-web-prod-test.yml
+++ b/.github/workflows/docker-compose-web-prod-test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and run Docker Compose
         run: |
-          mv .env.prod_template .env.prod
+          mv .env.prod_template .env
           docker compose -f compose.yaml -f compose.prod.yaml up -d --build
 
       - name: Wait for services to be healthy

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 data
 .vscode
 .env
+.env.prod
 build
 blockchain/truffle/contract_address.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 data
 .vscode
 .env
-.env.prod
 build
 blockchain/truffle/contract_address.json

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -218,4 +218,4 @@ if ENVIRONMENT == "production":
     SECURE_REDIRECT_EXEMPT = []
     SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-    WS_URL = "wss://localhost:443/ws/"
+    WS_URL = "wss://localhost:8443/ws/"

--- a/backend/oauth/tests.py
+++ b/backend/oauth/tests.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from accounts.models import CustomUser
+from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -32,7 +33,10 @@ class OAuthCallbackViewTests(APITestCase):
 
         response = self.client.get(reverse("oauth:callback"), {"code": "test_code"})
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
-        self.assertEqual(response.url, "http://localhost:3000/#/")
+        if settings.DEBUG == False:
+            self.assertEqual(response.url, "https://localhost:8443/#/")
+        else:
+            self.assertEqual(response.url, "http://localhost:3000/#/")
 
         user = CustomUser.objects.get(username="testuser")
         self.assertIsNotNone(user)

--- a/backend/oauth/views.py
+++ b/backend/oauth/views.py
@@ -12,7 +12,6 @@ from rest_framework.response import Response
 @api_view(["GET"])
 def oauth_view(request):
     if settings.DEBUG == False:
-        print("redirect ok!!!!")
         return redirect(
             f"https://api.intra.42.fr/oauth/authorize?client_id={os.environ.get('UID')}&redirect_uri=https://localhost:8443/api/oauth/callback/&response_type=code"
         )
@@ -25,8 +24,6 @@ def oauth_view(request):
 def oauth_callback_view(request):
     code = request.GET.get("code")
     error = request.GET.get("error")
-    print(code)
-    print(error)
     if error:
         return Response(
             {
@@ -38,9 +35,6 @@ def oauth_callback_view(request):
 
     if code:
         if settings.DEBUG == False:
-            print("post ok!!!")
-            print(os.environ.get("UID"))
-            print(os.environ.get("SECRET"))
             response = requests.post(
                 "https://api.intra.42.fr/oauth/token",
                 data={
@@ -62,11 +56,8 @@ def oauth_callback_view(request):
                     "redirect_uri": "http://localhost:8000/oauth/callback/",
                 },
             )
-        print(response)
         token_data = response.json()
-        print(token_data)
         access_token = token_data.get("access_token")
-        print(access_token)
 
         if access_token:
             user_info_response = requests.get(

--- a/backend/oauth/views.py
+++ b/backend/oauth/views.py
@@ -75,8 +75,18 @@ def oauth_callback_view(request):
 
             login(request, user)
             if settings.DEBUG == False:
-                return redirect("https://localhost:8443/#/")
-            return redirect("http://localhost:3000/#/")
+                response = redirect("https://localhost:8443/#/")
+            else:
+                response = redirect("http://localhost:3000/#/")
+
+            response.set_cookie(
+                key="token",
+                value="dummy",
+                max_age=86400,
+                secure=True,
+                samesite="Lax",
+            )
+            return response
     return Response(
         {
             "error": "No code provided",

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -17,8 +17,8 @@ services:
 
   frontend:
     environment: !override
-      - BACKEND_HOST=https://localhost:443/api
-      - BACKEND_WS_HOST=wss://localhost:443/ws
+      - BACKEND_HOST=https://localhost:8443/api
+      - BACKEND_WS_HOST=wss://localhost:8443/ws
     ports: !reset []
 
   web:
@@ -27,7 +27,7 @@ services:
       dockerfile: ./nginx/Dockerfile
     container_name: web
     ports:
-      - "443:443"
+      - "8443:443"
     depends_on:
       backend:
         condition: service_healthy

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -9,6 +9,8 @@ services:
     entrypoint: !override "/usr/src/app/entrypoint.sh"
     environment: !override
       - ENVIRONMENT=production
+    env_file: !override
+      - .env.prod
     development: !reset []
     ports: !reset []
 
@@ -19,6 +21,8 @@ services:
     environment: !override
       - BACKEND_HOST=https://localhost:8443/api
       - BACKEND_WS_HOST=wss://localhost:8443/ws
+    env_file: !override
+      - .env.prod
     ports: !reset []
 
   web:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -9,8 +9,6 @@ services:
     entrypoint: !override "/usr/src/app/entrypoint.sh"
     environment: !override
       - ENVIRONMENT=production
-    env_file: !override
-      - .env.prod
     development: !reset []
     ports: !reset []
 
@@ -21,8 +19,6 @@ services:
     environment: !override
       - BACKEND_HOST=https://localhost:8443/api
       - BACKEND_WS_HOST=wss://localhost:8443/ws
-    env_file: !override
-      - .env.prod
     ports: !reset []
 
   web:

--- a/frontend/views/pages/Login.js
+++ b/frontend/views/pages/Login.js
@@ -73,7 +73,6 @@ const Login = {
       .addEventListener("click", async (event) => {
         event.preventDefault();
         window.location.href = `${window.env.BACKEND_HOST}/oauth/`;
-        document.cookie = `token=dummy; path=/; Secure; SameSite=Strict; max-age=86400`;
       });
 
     document


### PR DESCRIPTION
## Oauth42を本番環境でも動くようにしました

- 42Oauth APIの設定を変更してもう一個追加してprod用にも対応しました
- 本番環境用の環境変数が入った`.env.prod_template`を用意しました
- HTTPS用のポートを8443に変更

```
mv .env.prod_template .env
```
で使ってください