### PR TITLE
[update] ELKへの接続にHTTPSを使用

### DIFF
--- a/elk/create_index_pattern.sh
+++ b/elk/create_index_pattern.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KIBANA_HOST="http://kibana:5601"
+KIBANA_HOST="https://kibana:5601"
 KIBANA_USER="elastic"
 KIBANA_PASS=${KIBANA_PASSWORD}
 INDEX_PATTERN_NAME="Logstash data view"
@@ -17,6 +17,7 @@ cat <<EOF > index-pattern.json
 EOF
 
 curl -X POST "${KIBANA_HOST}/api/data_views/data_view" \
+  --cacert /usr/share/logstash/config/certs/ca/ca.crt \
   -H "kbn-xsrf: string" \
   -H "Content-Type: application/json" \
   -u ${KIBANA_USER}:${KIBANA_PASS} \

--- a/elk/elk-services.yml
+++ b/elk/elk-services.yml
@@ -75,9 +75,16 @@ services:
       - XPACK_SECURITY_ENCRYPTIONKEY=${ENCRYPTION_KEY}
       - XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=${ENCRYPTION_KEY}
       - XPACK_REPORTING_ENCRYPTIONKEY=${ENCRYPTION_KEY}
+      - XPACK_SECURITY_ENABLED=true
+      - SERVER_SSL_ENABLED=true
+      - SERVER_SSL_CERTIFICATE=config/certs/es01/es01.crt
+      - SERVER_SSL_KEY=config/certs/es01/es01.key
+      - SERVER_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt
+      - SERVER_SSL_VERIFICATION_MODE=certificate
+      - SERVER_SSL_REDIRECT=true
     mem_limit: ${KB_MEM_LIMIT}
     healthcheck:
-      test: [ "CMD-SHELL", "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'" ]
+      test: [ "CMD-SHELL", "curl -s -I --cacert config/certs/ca/ca.crt https://localhost:5601 | grep -q 'HTTP/1.1 302 Found'" ]
       interval: 10s
       timeout: 10s
       retries: 120

--- a/elk/elk-services.yml
+++ b/elk/elk-services.yml
@@ -77,8 +77,8 @@ services:
       - XPACK_REPORTING_ENCRYPTIONKEY=${ENCRYPTION_KEY}
       - XPACK_SECURITY_ENABLED=true
       - SERVER_SSL_ENABLED=true
-      - SERVER_SSL_CERTIFICATE=config/certs/es01/es01.crt
-      - SERVER_SSL_KEY=config/certs/es01/es01.key
+      - SERVER_SSL_CERTIFICATE=config/certs/kibana/kibana.crt
+      - SERVER_SSL_KEY=config/certs/kibana/kibana.key
       - SERVER_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt
       - SERVER_SSL_VERIFICATION_MODE=certificate
       - SERVER_SSL_REDIRECT=true

--- a/elk/elk-services.yml
+++ b/elk/elk-services.yml
@@ -7,9 +7,10 @@ services:
       - ./setup_elk.sh:/usr/local/bin/setup_elk.sh
     env_file: ../.env
     user: "0"
-    command: [ "/bin/bash", "/usr/local/bin/setup_elk.sh" ]
+    command: ["/bin/bash", "/usr/local/bin/setup_elk.sh"]
     healthcheck:
-      test: [ "CMD-SHELL", "[ -f /usr/share/elasticsearch/config/certs/ca/ca.crt ]" ]
+      test:
+        ["CMD-SHELL", "[ -f /usr/share/elasticsearch/config/certs/ca/ca.crt ]"]
       interval: 1s
       timeout: 5s
       retries: 120
@@ -49,7 +50,11 @@ services:
         soft: -1
         hard: -1
     healthcheck:
-      test: [ "CMD-SHELL", "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'" ]
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'",
+        ]
       interval: 10s
       timeout: 10s
       retries: 120
@@ -84,7 +89,11 @@ services:
       - SERVER_SSL_REDIRECT=true
     mem_limit: ${KB_MEM_LIMIT}
     healthcheck:
-      test: [ "CMD-SHELL", "curl -s -I --cacert config/certs/ca/ca.crt https://localhost:5601 | grep -q 'HTTP/1.1 302 Found'" ]
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I --cacert config/certs/ca/ca.crt https://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
       interval: 10s
       timeout: 10s
       retries: 120


### PR DESCRIPTION
## ELKへの接続をHTTPSを使ってできるようにしました

```
docker compose -f compose.yaml -f compose.prod.yaml up --build
```
https://localhost:5601/ user: `elastic`, password: `changeme`でログインできます。

## TIPS
SSLについての理解が浅く、結構時間がかかってしまったので、

`ca.crt`、`kibana.crt`、および `es01.crt` は、ELKスタック（Elasticsearch、Kibana、Logstash）のセキュアな通信を実現するために使用されるSSL/TLS証明書です。それぞれの違いと役割について以下に詳しく説明します。

---

### 1. `ca.crt`（Certificate Authority証明書）

- **目的**: 認証局（CA）の証明書であり、他の証明書（例: `kibana.crt`、`es01.crt`）を発行・署名するために使用されます。
  
- **役割**:
  - **信頼の基盤**: CA証明書は信頼できる第三者として機能し、ELKスタック内の各サービス間の通信の信頼性を保証します。
  - **証明書の検証**: クライアントやサーバーは、通信相手の証明書が信頼できるCAによって署名されているかを確認するために使用します。

---

### 2. `kibana.crt`（Kibanaサーバー用証明書）

- **目的**: Kibanaサーバー自身のSSL/TLS証明書であり、クライアント（例: ブラウザ）とKibanaサーバー間のセキュアな通信を確立します。
  
- **役割**:
  - **通信の暗号化**: クライアントとKibana間のデータ通信を暗号化し、第三者による盗聴や改ざんを防ぎます。
  - **サーバーの認証**: クライアントが接続するKibanaサーバーが正当なものであることを証明します。

- **証明書の内容**:
  - **サブジェクト代替名（SAN）**に `kibana` や `localhost` が含まれている必要があります。

---

### 3. `es01.crt`（Elasticsearchノード用証明書）

- **目的**: Elasticsearchノード自身のSSL/TLS証明書であり、ノード間通信およびクライアントとElasticsearch間のセキュアな通信を確立します。
  
- **役割**:
  - **通信の暗号化**: Elasticsearchノード間、およびクライアントとElasticsearch間のデータ通信を暗号化します。
  - **サーバーの認証**: クライアントや他のノードが接続先のElasticsearchノードが正当なものであることを確認します。

- **証明書の内容**:
  - **サブジェクト代替名（SAN）**に `es01` や `localhost` が含まれている必要があります。

---

### まとめ

- **`ca.crt`**:
  - **役割**: 他の証明書の発行・署名を行う認証局として機能。
  - **使用場所**: 全てのサービスで信頼の基盤として利用。

- **`kibana.crt`**:
  - **役割**: Kibanaサーバーとクライアント間のセキュアな通信を提供。
  - **使用場所**: KibanaサービスのSSL設定に使用。

- **`es01.crt`**:
  - **役割**: Elasticsearchノード間およびクライアントとのセキュアな通信を提供。
  - **使用場所**: ElasticsearchサービスのSSL設定に使用。

これらの証明書を適切に設定・管理することで、ELKスタック全体のセキュリティを強化し、信頼性の高い通信環境を構築することができます。

### SAN（Subject Alternative Name）とは

SAN（Subject Alternative Name）は、SSL/TLS証明書の拡張フィールドの一つで、証明書が有効とする追加のドメイン名やIPアドレスを指定するために使用されます。主に以下の目的で利用されます。