### PR TITLE
[update] トーナメントが2周目以降できるように

### DIFF
--- a/backend/tournament/urls.py
+++ b/backend/tournament/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
         name="tournament-register",
     ),
     path(
-        "api/save-data/",
+        "api/save-data/<int:pk>/",
         SaveDataView.as_view(),
         name="save-data",
     ),

--- a/backend/tournament/views.py
+++ b/backend/tournament/views.py
@@ -59,6 +59,10 @@ class SaveDataView(APIView):
 
     def put(self, request, pk=None):
         match_data = request.data.get("currentMatch")
+        if not match_data:
+            return Response(
+                {"error": "No match data provided"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
             match = Match.objects.get(

--- a/frontend/views/pages/Gameplay.js
+++ b/frontend/views/pages/Gameplay.js
@@ -82,7 +82,7 @@ const Gameplay = {
 
             if (sessionStorage.getItem("isTournament") === "true") {
                 try {
-                    const response = await fetch(`${window.env.BACKEND_HOST}/tournament/api/save-data/`);
+                    const response = await fetch(`${window.env.BACKEND_HOST}/tournament/api/save-data/${localStorage.getItem("tournamentId")}/`);
     
                     if (!response.ok) {
                         const errorData = await response.json();
@@ -91,21 +91,24 @@ const Gameplay = {
                     }
     
                     const tournamentData = await response.json();
-                    console.log("Tournament data updated successfully:", tournamentData);
+                    console.log("Tournament data get successfully:", tournamentData);
     
                     const currentMatchId = parseInt(sessionStorage.getItem("currentMatch")) - 1;
     
                     if (tournamentData && tournamentData.matches) {
-                        tournamentData.matches[currentMatchId].player1_score = data.left_score;
-                        tournamentData.matches[currentMatchId].player2_score = data.right_score;
-                        tournamentData.matches[currentMatchId].winner = winner;
-    
-                        const postResponse = await fetch(`${window.env.BACKEND_HOST}/tournament/api/save-data/`, {
-                            method: "POST",
+						let currentMatch = tournamentData.matches[currentMatchId];
+
+                        currentMatch.player1_score = data.left_score;
+                        currentMatch.player2_score = data.right_score;
+                        currentMatch.winner = winner;
+						console.log("currentMatch", currentMatch);
+
+                        const postResponse = await fetch(`${window.env.BACKEND_HOST}/tournament/api/save-data/${localStorage.getItem("tournamentId")}/`, {
+                            method: "PUT",
                             headers: {
                                 "Content-Type": "application/json",
                             },
-                            body: JSON.stringify({ currentMatchId, tournamentData }),
+                            body: JSON.stringify({ currentMatch }),
                         });
     
                         if (!postResponse.ok) {

--- a/frontend/views/pages/Matches.js
+++ b/frontend/views/pages/Matches.js
@@ -20,7 +20,9 @@ const Matches = {
 
   async fetchTournamentData() {
     const response = await fetch(
-      `${window.env.BACKEND_HOST}/tournament/api/save-data/`
+      `${
+        window.env.BACKEND_HOST
+      }/tournament/api/save-data/${localStorage.getItem("tournamentId")}/`
     );
     if (!response.ok) throw new Error(`HTTP Error Status: ${response.status}`);
     return response;

--- a/frontend/views/pages/Tournament.js
+++ b/frontend/views/pages/Tournament.js
@@ -14,7 +14,9 @@ const Tournament = {
     // トーナメントデータがあり、終了していない場合は続きを行う
     try {
       const response = await fetch(
-        `${window.env.BACKEND_HOST}/tournament/api/save-data/`
+        `${
+          window.env.BACKEND_HOST
+        }/tournament/api/save-data/${localStorage.getItem("tournamentId")}/`
       );
 
       if (!response.ok) {
@@ -65,6 +67,7 @@ const Tournament = {
 
           if (response.ok) {
             console.log(data);
+            localStorage.setItem("tournamentId", data.id);
             window.location.hash = "#/gamesetting";
           } else {
             const errors = Object.entries(data)


### PR DESCRIPTION
## トーナメントが2周目以降できるようにしました

- トーナメント取得時にpkを使用するようにし、トーナメントごとのデータ操作を可能に
- pkをフロントエンドに保存しておくことでどのトーナメントかを判別できるように
- トーナメント更新時にはPUTを使用し、更新するデータだけを送るように

これでトーナメントの機能は一通り完成したかと思います