### PR TITLE
[update] CLIプログラムからゲームを作成できるように

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -44,8 +44,15 @@ const router = async () => {
   const body = null || document.getElementById("body_container");
   const footer = null || document.getElementById("footer_container");
 
-  const location = window.location.hash.slice(1).toLowerCase() || "/";
+  let location = window.location.hash.slice(1).toLowerCase() || "/";
   console.log(location);
+
+  const gameplayMatch = location.match(/^\/gameplay\.(\d+)/);  // 数字の部分をキャッチ
+  if (gameplayMatch) {
+    const settingId = gameplayMatch[1];  // settingId（例: '1'）を取得
+    sessionStorage.setItem("settingId", settingId);  // sessionStorage に保存
+    location = '/gameplay'; // locationを'/gameplay'に変更して遷移させる
+  }
 
   if (window.currentPage && window.currentPage.cleanup) {
     window.currentPage.cleanup();

--- a/frontend/views/pages/GameSetting.js
+++ b/frontend/views/pages/GameSetting.js
@@ -40,13 +40,12 @@ const GameSetting = {
         const responseData = await response.json();
         const settingId = responseData.id;
         console.log("Settings updated successfully:", settings);
-        sessionStorage.setItem("settingId", settingId);
         console.log("Settings ID saved to sessionStorage:", sessionStorage.getItem("settingId"));
         if (sessionStorage.getItem("isTournament") === "true") {
             window.location.hash = `#/matches`; // Matches画面へ遷移
             return;
         }
-        window.location.hash = `#/gameplay`; // Gameplay画面へ遷移
+        window.location.hash = `#/gameplay.${settingId}/`; // Gameplay画面へ遷移
         const tournamentButton = document.getElementById("navbar:tournament");
         if (tournamentButton) {
             tournamentButton.removeAttribute("href");

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+venv
+__pycache__

--- a/tools/cli_pong_client/requirements.txt
+++ b/tools/cli_pong_client/requirements.txt
@@ -1,1 +1,2 @@
 websocket-client
+requests

--- a/tools/cli_pong_client/srcs/cli_pong_client.py
+++ b/tools/cli_pong_client/srcs/cli_pong_client.py
@@ -111,9 +111,7 @@ class PaddleControl:
     def on_close(self, ws, close_status_code, close_msg):
         Utils.print_colored_message("red", "Disconnected\n")
 
-    def first_setup(self):
-        Utils.print_colored_message("green", "Welcome to Pong Game!!!\n")
-
+    def join_game(self):
         Utils.print_colored_message("green", "Please type game id you want to play. ")
         while (True):
             self.game_id = sys.stdin.readline().strip()
@@ -123,7 +121,24 @@ class PaddleControl:
             else:
                 Utils.print_colored_message("red", "Invalid input. Please type a number. ")
         Utils.print_colored_message("yellow", f"\nOK. The Game id is \n\n\" ----- " + self.game_id + " ----- \"\n")
-    
+
+    def create_game(self):
+        pass
+
+    def first_setup(self):
+        Utils.print_colored_message("green", "Welcome to Pong Game!!!\n")
+        Utils.print_colored_message("green", "Press 1 to join an existing game, or 2 to create your own!")
+        while (True):
+            user_input = sys.stdin.readline().strip()
+            if user_input == '1':
+                self.join_game()
+                break
+            elif user_input == '2':
+                self.create_game()
+                break
+            else:
+                Utils.print_colored_message("red", "Invalid input. Please type 1(Join) or 2(Create).")
+
         Utils.print_colored_message("green", "Which paddle do you want to control?\nType D(Left) or K(Right)")
         while (True):
             user_input = sys.stdin.readline().strip()

--- a/tools/cli_pong_client/srcs/cli_pong_client.py
+++ b/tools/cli_pong_client/srcs/cli_pong_client.py
@@ -167,6 +167,7 @@ class PaddleControl:
                 break
             elif user_input == '3':
                 ball_velocity = "slow"
+                break
             else:
                 Utils.print_colored_message("red", "Invalid input. Please type 1(Fast) or 2(Normal) or 3(Slow).")
 

--- a/tools/cli_pong_client/srcs/cli_pong_client.py
+++ b/tools/cli_pong_client/srcs/cli_pong_client.py
@@ -6,17 +6,19 @@ import os
 import tty
 import termios
 import select
+import requests
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from .utils import Utils
 
-base_url = "wss://localhost:8443/gameplay.ws/ponglogic/"
+base_ws_url = "wss://localhost:8443/gameplay.ws/ponglogic/"
+game_setting_url = "https://localhost:8443/42pong.api/gameplay/gamesetting/api/"
 
 class PaddleControl:
     def __init__(self):
         self.game_id = None
-        self.url = ""
+        self.ws_url = ""
         self.running = True
         self.paddle_side = ""
         self.down_key = ""
@@ -116,14 +118,89 @@ class PaddleControl:
         while (True):
             self.game_id = sys.stdin.readline().strip()
             if self.game_id.isnumeric():
-                self.url = base_url + self.game_id + "/"
+                self.ws_url = base_ws_url + self.game_id + "/"
                 break
             else:
                 Utils.print_colored_message("red", "Invalid input. Please type a number. ")
         Utils.print_colored_message("yellow", f"\nOK. The Game id is \n\n\" ----- " + self.game_id + " ----- \"\n")
 
+    def post_game_setting(self, ball_velocity, ball_size, map):
+        game_setting = {
+            "ball_velocity": ball_velocity,
+            "ball_size": ball_size,
+            "map": map
+        }
+        headers = {
+            "Content-Type": "application/json",  # 必須: JSON形式を指定
+        }
+
+        try:
+            response = requests.post(game_setting_url, json=game_setting, headers=headers, verify=False)
+
+            # レスポンスのステータスコードをチェック
+            if response.status_code == 201:
+                self.game_id = response.json().get('id')
+                self.ws_url = base_ws_url + str(self.game_id) + "/"
+                Utils.print_colored_message("yellow", f"Game created successfully. The Game id is \n\n\" ----- " + str(self.game_id) + " ----- \"\n")
+            else:
+                Utils.print_colored_message("red", f"Failed to create game. Server responded with status code {response.status_code}.")
+                sys.exit(1)
+
+        except requests.RequestException as e:
+            # リクエストのエラー（接続エラーなど）
+            Utils.print_colored_message("red", f"Error occurred while creating game: {str(e)}")
+            sys.exit(1)
+
     def create_game(self):
-        pass
+        Utils.print_colored_message("green", "Let's set up a new game.\n")
+        ball_velocity = ""
+        ball_size = ""
+        map = ""
+        Utils.print_colored_message("green", "Select ball velocity.\nType 1(Fast), 2(Normal), or 3(Slow)")
+        while (True):
+            user_input = sys.stdin.readline().strip()
+            if user_input == '1':
+                ball_velocity = "fast"
+                break
+            elif user_input == '2':
+                ball_velocity = "normal"
+                break
+            elif user_input == '3':
+                ball_velocity = "slow"
+            else:
+                Utils.print_colored_message("red", "Invalid input. Please type 1(Fast) or 2(Normal) or 3(Slow).")
+
+        Utils.print_colored_message("green", "Select ball size.\nType 1(Big), 2(Normal), or 3(Small)")
+        while (True):
+            user_input = sys.stdin.readline().strip()
+            if user_input == '1':
+                ball_size = "big"
+                break
+            elif user_input == '2':
+                ball_size = "normal"
+                break
+            elif user_input == '3':
+                ball_size = "small"
+                break
+            else:
+                Utils.print_colored_message("red", "Invalid input. Please type 1(Big) or 2(Normal) or 3(Small).")
+
+        Utils.print_colored_message("green", "Select map.\nType 1(A), 2(B), or 3(C)")
+        while (True):
+            user_input = sys.stdin.readline().strip()
+            if user_input == '1':
+                map = "a"
+                break
+            elif user_input == '2':
+                map = "b"
+                break
+            elif user_input == '3':
+                map = "c"
+                break
+            else:
+                Utils.print_colored_message("red", "Invalid input. Please type 1(Big) or 2(Normal) or 3(Small).")
+
+        self.post_game_setting(ball_velocity, ball_size, map)
 
     def first_setup(self):
         Utils.print_colored_message("green", "Welcome to Pong Game!!!\n")
@@ -157,12 +234,12 @@ class PaddleControl:
         self.first_setup()
     
         Utils.print_colored_message("white", "Connecting to: ")
-        Utils.print_colored_message("yellow", self.url + "\n")
+        Utils.print_colored_message("yellow", self.ws_url + "\n")
     
         # WebSocketの設定と接続
         websocket.enableTrace(False)  # デバッグ情報を出力
         ws_app = websocket.WebSocketApp(
-            self.url,
+            self.ws_url,
             on_open=self.on_open,
             on_message=self.on_message,
             on_error=self.on_error,

--- a/tools/cli_pong_client/srcs/cli_pong_client.py
+++ b/tools/cli_pong_client/srcs/cli_pong_client.py
@@ -202,6 +202,8 @@ class PaddleControl:
                 Utils.print_colored_message("red", "Invalid input. Please type 1(Big) or 2(Normal) or 3(Small).")
 
         self.post_game_setting(ball_velocity, ball_size, map)
+        Utils.print_colored_message("white", "Please access the following URL from the browser.")
+        Utils.print_colored_message("yellow", f"https://localhost:8443/#/gameplay.{self.game_id}/\n")
 
     def first_setup(self):
         Utils.print_colored_message("green", "Welcome to Pong Game!!!\n")


### PR DESCRIPTION
**説明**
CLIプログラムからゲームを作成できるようにしました。
ブラウザとCLIプログラムのどちらからゲームを作成してもgameplayがgame_id(gamesetting_id)を識別できるように、urlにidを含めるようにしました。

**確認方法**
```
docker compose -f compose.yaml -f compose.prod.yaml up --build
```
で起動した後、/tools/cli_pong_client/に移動し、README.mdに従ってCLIプログラムを起動してください。
指示に従って試合を作成し、指示されたurlにブラウザからアクセスしてください。
(※CLIプログラムで最初に「2」を選択することに気をつけてください！)

実際にプレイできることを確認してください。

**補足**
CLIからgamesettingにpostをする際に、認証を行っていないので別issueで実装します