### PR TITLE
[fix] ゲーム設定をSessionStorageにセットする部分を復元

### DIFF
--- a/frontend/views/pages/GameSetting.js
+++ b/frontend/views/pages/GameSetting.js
@@ -40,6 +40,7 @@ const GameSetting = {
         const responseData = await response.json();
         const settingId = responseData.id;
         console.log("Settings updated successfully:", settings);
+        sessionStorage.setItem("settingId", settingId);
         console.log("Settings ID saved to sessionStorage:", sessionStorage.getItem("settingId"));
         if (sessionStorage.getItem("isTournament") === "true") {
             window.location.hash = `#/matches`; // Matches画面へ遷移


### PR DESCRIPTION
トーナメントが動かなくなっていたのでセッションストレージを復活させました。
小手先の対策ですが他の修正法(クエリを使う等)は大変そうなのでやりませんでした。