### PR TITLE
[add] blockchain dataを可視化

### DIFF
--- a/backend-services/tournament/blockchain/truffle/contract_address.json
+++ b/backend-services/tournament/blockchain/truffle/contract_address.json
@@ -1,3 +1,0 @@
-{
-  "address": "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B"
-}

--- a/backend-services/tournament/tournament/views.py
+++ b/backend-services/tournament/tournament/views.py
@@ -109,7 +109,7 @@ class SaveDataView(APIView):
                     player1_score=match.player1_score,
                     player2_score=match.player2_score
                 )
-                print(f"Blockchain transaction receipt: {receipt}")
+                logger.info(f"Blockchain transaction receipt: {receipt}")
             except Exception as e:
                 return Response(
                     {"error": f"An error occurred while recording match on blockchain: {e}"},

--- a/backend-services/tournament/tournament/views.py
+++ b/backend-services/tournament/tournament/views.py
@@ -109,7 +109,6 @@ class SaveDataView(APIView):
                     player1_score=match.player1_score,
                     player2_score=match.player2_score
                 )
-                logger.info(f"Blockchain transaction receipt: {receipt}")
             except Exception as e:
                 return Response(
                     {"error": f"An error occurred while recording match on blockchain: {e}"},

--- a/backend-services/tournament/tournament/web3_ganache_connect.py
+++ b/backend-services/tournament/tournament/web3_ganache_connect.py
@@ -106,6 +106,22 @@ class TournamentContract:
     def get_match(self, tournament_id, match_number):
         match_details = self.contract.functions.getMatch(tournament_id, match_number).call()
         return match_details
+    
+    # イベントフィルタの作成とログの取得
+    def get_event_logs(self, event_name, from_block=0, to_block='latest'):
+        try:
+            # キーワード引数を使用してイベントフィルタを作成
+            event_filter = self.contract.events[event_name].create_filter(
+                from_block=from_block,
+                to_block=to_block
+            )
+            # フィルタに一致するすべてのエントリを取得
+            for event in event_filter.get_all_entries():
+                logger.info(f"Event: {event}")
+                logger.info(f"Event Args: {event['args']}")
+        except Exception as e:
+            logger.error(f"An error occurred while getting event logs: {e}")
+
 
 def record_match_on_blockchain(
     tournament_id,
@@ -143,6 +159,9 @@ def record_match_on_blockchain(
             player1_score=player1_score,
             player2_score=player2_score
         )
+
+        # イベントログの取得
+        tournament_contract.get_event_logs("MatchRecorded")
         return receipt
 
     except Exception as e:

--- a/backend-services/tournament/tournament/web3_ganache_connect.py
+++ b/backend-services/tournament/tournament/web3_ganache_connect.py
@@ -2,6 +2,9 @@ from web3 import Web3
 import json
 import os
 from eth_account import Account
+import logging
+
+logger = logging.getLogger("tournament")
 
 ABI_PATH = "/usr/src/app/contracts/TournamentData.json"
 ADDRESS_PATH = "/usr/src/app/addresses/contract_address.json"
@@ -23,7 +26,7 @@ class TournamentContract:
     def connect_to_ganache(self):
         web3 = Web3(Web3.HTTPProvider(self.ganache_url))
         if web3.is_connected():
-            print("Successfully connected to Ganache")
+            logger.info("Successfully connected to Ganache")
             return web3
         else:
             raise ConnectionError("Failed to connect to Ganache")
@@ -62,8 +65,8 @@ class TournamentContract:
         account = Account.from_mnemonic(self.mnemonic, account_path=account_path)
         private_key = account.key
         address = account.address
-        print(f"Address: {address}")
-        print(f"Private Key: {private_key.hex()}")
+        logger.info(f"Address: {address}")
+        logger.info(f"Private Key: {private_key.hex()}")
         return address, private_key
 
     # トランザクションのビルドと送信
@@ -122,11 +125,11 @@ def record_match_on_blockchain(
         try:
             tournament_details = tournament_contract.contract.functions.tournaments(tournament_id).call()
             if not tournament_details[0]:  # トーナメントIDが0の場合は存在しないとみなす
-                print(f"Tournament with ID {tournament_id} does not exist. Creating new tournament.")
+                logger.info(f"Tournament with ID {tournament_id} does not exist. Creating new tournament.")
                 tournament_contract.create_tournament(f"Auto Tournament {tournament_id}", timestamp)
         except Exception as e:
-            print(f"Error while checking tournament existence: {e}")
-            print(f"Creating new tournament with ID {tournament_id}")
+            logger.info(f"Error while checking tournament existence: {e}")
+            logger.info(f"Creating new tournament with ID {tournament_id}")
             tournament_contract.create_tournament(f"Auto Tournament {tournament_id}", timestamp)
 
         # 試合の記録
@@ -143,15 +146,15 @@ def record_match_on_blockchain(
         return receipt
 
     except Exception as e:
-        print(f"An error occurred while recording match on blockchain: {e}")
+        logger.info(f"An error occurred while recording match on blockchain: {e}")
         raise
 
 def get_match_from_blockchain(tournament_id, match_number):
     try:
         tournament_contract = TournamentContract()
         match_details = tournament_contract.get_match(tournament_id, match_number)
-        print(f"Match details: {match_details}")
+        logger.info(f"Match details: {match_details}")
         return match_details
     except Exception as e:
-        print(f"An error occurred while retrieving match from blockchain: {e}")
+        logger.info(f"An error occurred while retrieving match from blockchain: {e}")
         raise


### PR DESCRIPTION
やったこと：
ブロックチェーンに保存されたデータをターミナルから見れるようにしました

確認方法：
`docker compose -f compose.yaml -f compose.prod.yaml up --build`で起動後、
トーナメントゲーム開始してください。試合後に以下のようなログが出ることを確認できると思います。試合後のスコアや戦ったplayerのidなどが適切に出ていることを確認してください。

また、２試合目、３試合目に進むたびにそれまで保存されていたデータ一覧が表示されるようになっています。
例）２試合目終了後は１試合目の結果と２試合目の結果が出力される

出力例）
```
tournament    | [2025-01-17 13:34:49] INFO | get_event_logs | tournament | Event Args: AttributeDict({'tournamentId': 1, 'round': 1, 'matchNumber': 1, 'timestamp': 1737088416, 'player1Id': 1, 'player2Id': 6, 'player1Score': 15, 'player2Score': 3, 'winnerId': 1})
tournament    | [2025-01-17 13:34:49] INFO | put | tournament | Successfully updated match 1 in tournament 1
```